### PR TITLE
v0.30.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+_org/*.org

--- a/src/any.ts
+++ b/src/any.ts
@@ -18,7 +18,7 @@ type _ = unknown
 type id<type> = type
 interface object_ extends id<object> { }
 
-type function_<type extends any_.function = any.function> = type
+type function_<type extends any_.function = any_.function> = type
 
 declare namespace any_ {
   // aliased exports

--- a/src/associative/associative.ts
+++ b/src/associative/associative.ts
@@ -166,9 +166,7 @@ type keys<type extends Any>
 declare const keyof: <type extends Any>(assoc: type) => Assoc.keyof<type>
 type keyof<type extends Any> = Exclude<keyof type, number | size$>
 
-/**
- * TODO: see if you can get rid of this somehow
- */ // @ts-expect-error - internal use only
+/** @ts-expect-error - internal use only */
 class assoc<const type extends any.object> extends impl.base<type> { }
 type associative<type extends any.entries> = make<type, any.entries, Assoc<of<type>>>
 

--- a/src/show/associative.ts
+++ b/src/show/associative.ts
@@ -129,7 +129,7 @@ namespace impl {
         Object.assign(this, order, named);
       }
     } as never
-  /* @ts-expect-error - internal use only */
+  // @ts-expect-error - internal use only
   export class assoc<
     const named extends any.object,
     const order extends any.indexedby<len$>


### PR DESCRIPTION
changelog:
- fix: resolves type-error with the `assoc` module where the @ts-expect-error directive was getting stripped from the output
- fix: exports the underlying type that `any.function` extends so the compiler knows about it