### PR TITLE
release: v0.36.0

### DIFF
--- a/bin/version.ts
+++ b/bin/version.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env pnpx tsx
+import * as FileSystem from "node:fs"
+import * as Url from "node:url"
+import * as OS from "node:os"
+
+type intercalate<acc extends string, xs extends readonly unknown[], btwn extends string>
+  = xs extends readonly [infer head extends string, ...infer tail]
+  ? intercalate<acc extends "" ? `${head}` : `${acc}${btwn}${head}`, tail, btwn>
+  : acc
+  ;
+
+type join<
+  xs extends readonly string[],
+  btwn extends string = ""
+> = intercalate<"", xs, `${btwn}`>
+
+const join
+  : <btwn extends string>(btwn: btwn) => <const xs extends readonly string[]>(...xs: xs) => join<xs, btwn>
+  = (btwn) => (...xs) => xs.join(btwn) as never
+
+const root: `~` = Url.fileURLToPath(new URL("..", import.meta.url)) as never
+const versionFile = root.concat(join("/")("src", "version.ts"))
+
+declare namespace Cause {
+  interface PathNotFound<path extends string = string> {
+    readonly tag: "PathNotFound";
+    readonly message: `Path not found, received: \`${path}\`` | `Path not found`
+  }
+}
+namespace Cause {
+  export const PathNotFound = (path: unknown): PathNotFound => ({
+    tag: "PathNotFound",
+    message: typeof path === "string" ? `Path not found, received: \`${JSON.stringify(path)}\`` : `Path not found`
+  })
+}
+
+function readFile(filepath: `${typeof root}${string}`): string | Cause.PathNotFound {
+  try { return FileSystem.readFileSync(filepath).toString("utf-8") }
+  catch (err) { return Cause.PathNotFound(err) }
+}
+
+function writeFile(filepath: `${typeof root}${string}`): (contents: string) => void | Cause.PathNotFound {
+  return (contents) => {
+    try { return FileSystem.writeFileSync(filepath, contents) }
+    catch (err) { return Cause.PathNotFound(err) }
+  }
+}
+
+const versionTemplate = (version: string) =>
+  `export const ANY_TS_VERSION = "${version}" as const${OS.EOL}`
+    .concat(`export type ANY_TS_VERSION = typeof ANY_TS_VERSION`)
+
+/**
+ * Reads the package version from `package.json` and writes it as
+ * a value to `src/version.ts`.
+ * 
+ * This function is called by the script that publishes the package,
+ * and makes sure that the `ANY_TS_VERSION` identifier that ships
+ * with `any-ts` stays up to date with the actual version that's 
+ * published.
+ */
+const writeVersion = () => {
+  const fileContents = readFile(`${root}package.json`)
+  if (typeof fileContents === "object") throw fileContents
+  const json = JSON.parse(fileContents)
+  if ("version" in json && typeof json.version === "string") {
+    console.log(`\nWriting package version \`${json.version}\` to:\n${versionFile}\n`)
+    writeFile(versionFile)(versionTemplate(json.version))
+  }
+}
+
+const main = () => {
+  /** 
+   * Writes the version from `package.json#version` to `src / version.ts`.
+   * We write the version as a TypeScript string literal and export it
+   * from the library as a type-level indicator of what version of the
+   * library users have installed.
+   */
+  writeVersion()
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "any-ts",
   "private": false,
-  "version": "0.35.4",
+  "version": "0.36.0",
   "author": "Andrew Jarrett <ahrjarrett@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",
@@ -11,12 +11,13 @@
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "check": "tsc --noEmit",
     "clean": "rm -rf dist node_modules",
-    "lint": "tsc",
-    "release": "npm publish",
-    "release-anyway": "npm publish --no-git-checks"
+    "lint": "tsc --noEmit",
+    "release": "./bin/version.ts && pnpm publish",
+    "release-anyway": "pnpm run release --no-git-checks"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
+    "@types/node": "^20.11.24",
     "init": "^0.1.2",
     "tsup": "^8.0.1",
     "typescript": "5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ devDependencies:
   '@changesets/cli':
     specifier: ^2.27.1
     version: 2.27.1
+  '@types/node':
+    specifier: ^20.11.24
+    version: 20.11.24
   init:
     specifier: ^0.1.2
     version: 0.1.2
@@ -643,6 +646,12 @@ packages:
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    dev: true
+
+  /@types/node@20.11.24:
+    resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/normalize-package-data@2.4.4:
@@ -2595,6 +2604,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /universalify@0.1.2:

--- a/src/any-namespace.ts
+++ b/src/any-namespace.ts
@@ -1,14 +1,17 @@
 export type { any_ as any, any as any_ }
+export type { ANY_TS_VERSION } from "./version"
 
 import type { any } from "./any"
 import type { some } from "./any"
 import type { to } from "./to"
 import type { pathsof } from "./paths/paths"
-
-
+import type { ANY_TS_VERSION } from "./version"
 
 declare namespace any_ {
-  export type {
+  export {
+    type ANY_TS_VERSION as VERSION,
+  }
+  export {
     string_ as string,
     number_ as number,
     boolean_ as boolean,
@@ -17,7 +20,7 @@ declare namespace any_ {
   }
 
   // 🡓🡓 aliases 🡓🡓
-  export type {
+  export {
     arrayof as arrayOf,
     dictionary as dict,
     indexedby as indexedBy,

--- a/src/any.ts
+++ b/src/any.ts
@@ -311,10 +311,6 @@ declare namespace distributive {
 // ambient `any`), otherwise the aliases it exports such as `any.object_` will 
 // not be preserved.
 namespace any_ {
-  export type PKG_VERSION = typeof PKG_VERSION
-  // TODO: generate this identifier from manifest
-  export const PKG_VERSION = `0.35.4` as const
-
   /** @internal */
   type id<type> = type
   /** @internal */

--- a/src/err/enforce.ts
+++ b/src/err/enforce.ts
@@ -141,6 +141,32 @@ declare namespace enforce {
     : (unknown)
     ;
 
+  type stringLiteral<type extends string>
+    = [string] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : (unknown)
+    ;
+
+  type numberLiteral<type extends number>
+    = [number] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : (unknown)
+    ;
+
+  type booleanLiteral<type extends boolean>
+    = [boolean] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : (unknown)
+    ;
+
+  type numericLiteral<type extends number | bigint>
+    = [number] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : [bigint] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : (unknown)
+    ;
+
+  type bigintLiteral<type extends bigint>
+    = [bigint] extends [type] ? Fn.return<typeof Err.Literal<type>>
+    : (unknown)
+    ;
+
   type integer<type>
     = [number.is.integer<type>] extends [true] ? (unknown)
     : Fn.return<typeof Err.Integer<type>>

--- a/src/err/err.ts
+++ b/src/err/err.ts
@@ -26,10 +26,12 @@ declare namespace URI {
 type Msg = typeof Msg
 const Msg = {
   /** TODO: switch over to an HKT impl */
+  BigintLiteral: "Expected a bigint literal",
+  BooleanLiteral: "Expected a boolean literal",
   Integer: "Expected an integer",
   IsNotAssignableTo: "Expected input to not be assignable, but input was assignable instead",
   KeyUniqueness: "Expected keys to be unique, but encountered 1 or more duplicate keys",
-  Literal: "Expected a literal type, but encountered a non-literal instead",
+  Literal: "Expected a string literal, numeric literal, or boolean literal",
   MaxOneProp: "Expected a non-object type, or an object type with at most 1 property",
   Natural: "Expected a natural number",
   Negative: "Expected a negative number",
@@ -39,12 +41,15 @@ const Msg = {
   NonEmptyString: "Expected a non-empty string, but got an empty string instead",
   NoExcessProps: "Expected inputs to share an index signature, but encountered excess props",
   NonLiteral: "Expected a non-literal type, but encountered a literal instead",
+  NumberLiteral: "Expected a number literal",
   Numeric: "Expected a numeric type, for example `number` or `bigint`",
+  NumericLiteral: "Expected a numeric literal",
   Positive: "Expected a positive number",
   Shallow: "Expected a primitive type or a shallow array",
   SingleCharGotLonger: "Expected to receive a single-char string, but encountered a string containing more than 1 character instead",
   SingleCharGotShorter: "Expected to receive a single-char string, but encountered an empty string instead",
   SingleCharGotUniversal: "Expected to receive a single-char string, but encountered the universal string type instead",
+  StringLiteral: "Expected a string literal",
 } as const
 
 declare namespace Case {

--- a/src/traversable/traversable.ts
+++ b/src/traversable/traversable.ts
@@ -7,7 +7,6 @@ import type { any } from "../any-namespace"
 import type { empty, nonempty } from "../empty"
 
 import type { never } from "../semantic-never/exports"
-import type { assert, expect } from '../test/test';
 
 declare namespace impl {
   type unfold<path extends any.array<any.index>, leaf = unknown>
@@ -79,35 +78,3 @@ declare namespace traversal {
     ;
 }
 
-
-type leaf = typeof leaf
-declare const leaf: unique symbol
-
-export type __traversal_of__ = [
-  //        ^?
-  expect<assert.equivalent<traversal.of<leaf, []>, leaf>>,
-  expect<assert.equivalent<traversal.of<{ a: leaf }, ["a"]>, leaf>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: leaf } }, ["a", "b"]>, leaf>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: { c: leaf } } }, ["a", "b", "c"]>, leaf>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: { c: leaf } } }, []>, { a: { b: { c: leaf } } }>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: { c: leaf } } }, ["a"]>, { b: { c: leaf } }>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: { c: leaf } } }, ["a", "b"]>, { c: leaf }>>,
-  expect<assert.equivalent<traversal.of<{ a: { b: { c: leaf } } }, ["a", "b", "c"]>, leaf>>,
-]
-
-export type __traversable_by__ = [
-  // ^?
-  expect<assert.equal<traversable.by<[]>, unknown>>,
-  expect<assert.equal<traversable.by<["a"]>, { a: unknown }>>,
-  expect<assert.equal<traversable.by<["a", "b"]>, { a: { b: unknown } }>>,
-  expect<assert.equal<traversable.by<["a", "b", "c"]>, { a: { b: { c: unknown } } }>>,
-  expect<assert.equal<traversable.by<[], leaf>, leaf>>,
-  expect<assert.equal<traversable.by<["a"], { "a": 0 }>, { a: 0 }>>,
-  expect<assert.equal<traversable.by<["a", "b"], { a: { b: leaf } }>, { a: { b: leaf } }>>,
-  expect<assert.equal<traversable.by<["a", "b", "c"], { a: { b: { c: leaf } } }>, { a: { b: { c: leaf } } }>>,
-]
-
-export type __nonempty_path__ = expect<assert.equal<nonempty.path<0, [1, 2, 3]>, readonly [0, 1, 2, 3]>>
-//   ^?
-export type __nonempty_pathLeft__ = expect<assert.equal<nonempty.pathLeft<[1, 2, 3], 4>, readonly [1, 2, 3, 4]>>
-//   ^?

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+export const ANY_TS_VERSION = "0.36.0" as const
+export type ANY_TS_VERSION = typeof ANY_TS_VERSION

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
- infra: adds publish script that reads the package version from `package.json` and writes the version as a TypeScript type to `src/version.ts`
- feat: exports `VERSION` as a type-level reflection of the package type (available at the root as `ANY_TS_VERSION` or on the `any` namespace as `any.VERSION`)
- feat: adds new `enforce` variants [`stringLiteral`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.36.0?expand=1#diff-4cd8a7e6515d1016d3809f17c8f67e48f39cffdd9891efb9f1ec07dc5ea42ebaR144-R147), [`numberLiteral`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.36.0?expand=1#diff-4cd8a7e6515d1016d3809f17c8f67e48f39cffdd9891efb9f1ec07dc5ea42ebaR149-R152), [`numericLiteral`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.36.0?expand=1#diff-4cd8a7e6515d1016d3809f17c8f67e48f39cffdd9891efb9f1ec07dc5ea42ebaR149-R152), [`booleanLiteral`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.36.0?expand=1#diff-4cd8a7e6515d1016d3809f17c8f67e48f39cffdd9891efb9f1ec07dc5ea42ebaR154-R157), [`bigintLiteral`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.36.0?expand=1#diff-4cd8a7e6515d1016d3809f17c8f67e48f39cffdd9891efb9f1ec07dc5ea42ebaR159-R162)