### PR TITLE
release: v0.36.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "any-ts",
   "private": false,
-  "version": "0.36.5",
+  "version": "0.36.6",
   "author": "Andrew Jarrett <ahrjarrett@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/err/catch.spec.ts
+++ b/src/err/catch.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, assert } from "../test/exports"
+import type { any } from "../any-namespace"
+import type { nonempty } from "../empty"
+
+import type { Catch } from "./catch"
+import { mutable } from "../mutable/exports"
+
+declare const tuple: [[1, 2], [3, 4]]
+declare const unionNontuple: number[] | string[]
+declare const unionTuple:
+  | [[1, 2], [3, 4]]
+  | [[4, 5], [6, 7]]
+declare const nontuple: number[]
+
+declare function testUnion<const xss extends Catch.union<xss, any.array<nonempty.array>>>(xss: xss): mutable<["catch_union", xss]>
+declare function testUnion<const xss extends Catch.union<xss, any.array<nonempty.array>>>(...xss: xss): mutable<["catch_union", xss]>
+declare function testUnion<const xss extends Catch.nonunion<xss, any.array<nonempty.array>>>(xss: xss): mutable<["catch_nonunion", xss]>
+declare function testUnion<const xss extends Catch.nonunion<xss, any.array<nonempty.array>>>(...xss: xss): mutable<["catch_nonunion", xss]>
+
+declare function testTuple<const xs extends Catch.nonunion<Catch.tuple<xs, any.array>, any.array>>(xs: xs): mutable<["catch_tuple", xs]>
+declare function testTuple<const xs extends Catch.tuple<xs, any.array>>(xs: xs): mutable<["catch_union_tuple", xs]>
+declare function testTuple<const xs extends Catch.nontuple<Catch.union<xs, any.array>, any.array>>(xs: xs): mutable<["catch_union_nontuple", xs]>
+declare function testTuple<const xs extends Catch.nontuple<xs, any.array>>(xs: xs): mutable<["catch_nontuple", xs]>
+
+declare function testTuple<const xs extends Catch.nontuple<Catch.union<xs, any.array>, any.array>>(...xs: xs): mutable<["catch_union_nontuple", xs]>
+declare function testTuple<const xs extends Catch.tuple<xs, any.array>>(...xs: xs): mutable<["catch_tuple", xs]>
+declare function testTuple<const xs extends Catch.nontuple<xs, any.array>>(...xs: xs): mutable<["catch_nontuple", xs]>
+declare function testTuple<const xs extends Catch.union<Catch.tuple<xs, any.array>, any.array>>(...xs: xs): mutable<["catch_union_tuple", xs]>
+
+declare const nonliteral: string
+declare const literal: "hey"
+declare function testLiteral<type extends Catch.nonliteral<type>>(literal: type): ["nonliteral", type]
+declare function testLiteral<type extends Catch.literal<type>>(literal: type): ["literal", type]
+
+namespace Spec {
+  describe("Catch", () => [
+    // ^?
+    describe("union", t => [
+      expect(t.assert.equal(testUnion(unionTuple), mutable(["catch_union", unionTuple]))),
+      expect(t.assert.equal(testUnion(...unionTuple), mutable(["catch_union", unionTuple]))),
+    ] as const),
+    describe("nonunion", t => [
+      expect(t.assert.equal(testUnion(tuple), mutable(["catch_nonunion", tuple]))),
+      expect(t.assert.equal(testUnion(...tuple), mutable(["catch_nonunion", tuple]))),
+    ] as const),
+
+    describe("tuple", t => [
+      expect(t.assert.equal(testTuple(tuple), mutable(["catch_tuple", tuple]))),
+      expect(t.assert.equal(testTuple(...tuple), mutable(["catch_tuple", tuple]))),
+    ]),
+    describe("nontuple", t => [
+      expect(t.assert.equal(testTuple(nontuple), mutable(["catch_nontuple", nontuple]))),
+      expect(t.assert.equal(testTuple(...nontuple), mutable(["catch_nontuple", nontuple]))),
+    ]),
+
+    describe("unionNontuple", t => [
+      expect(t.assert.equal(testTuple(unionNontuple), mutable(["catch_union_nontuple", unionNontuple]))),
+      expect(t.assert.equal(testTuple(...unionNontuple), mutable(["catch_union_nontuple", unionNontuple]))),
+    ]),
+
+    // TODO: figure out if you can pull this off
+    // describe("unionTuple", t => [
+    //   expect(t.assert.equal(testTuple(unionTuple), mutable(["catch_union_tuple", unionTuple]))),
+    //   expect(t.assert.equal(testTuple(...unionTuple), mutable(["catch_union_tuple", unionTuple]))),
+    // ]),
+
+    describe("literal", t => [
+      expect(t.assert.equal(testLiteral(literal), mutable(["literal", literal]))),
+    ]),
+    describe("nonliteral", t => [
+      expect(t.assert.equal(testLiteral(nonliteral), mutable(["nonliteral", nonliteral]))),
+    ]),
+  ] as const)
+  //   ^?
+}

--- a/src/err/catch.ts
+++ b/src/err/catch.ts
@@ -1,26 +1,68 @@
 export type { Catch }
 
 import type { any } from "../any-namespace"
+import type { Union } from "../union/exports";
+import type { never } from "../semantic-never/exports";
+import { nonempty } from "../empty";
 
-type nonTuple<xs, constraint extends any.array>
+type tuple<xs, constraint extends any.array>
   = [xs] extends [constraint]
-  ? [number] extends [xs["length"]] ? constraint
-  : never
-  : never
+  ? [number] extends [xs["length"]] ? never.as.nothing
+  : constraint
+  : never.close.unmatched_expr
   ;
 
-type nonLiteral<xs, constraint extends any.literal = any.literal>
+type nontuple<xs, constraint extends any.array>
+  = [xs] extends [constraint]
+  ? [number] extends [xs["length"]] ? constraint
+  : never.as.nothing
+  : never.close.unmatched_expr
+  ;
+
+type literal<xs, constraint extends any.literal = any.literal>
+  = [xs] extends [any.literal]
+  ? [number] extends [xs] ? never.as.nothing
+  : [string] extends [xs] ? never.as.nothing
+  : [boolean] extends [xs] ? never.as.nothing
+  : constraint
+  : never.close.unmatched_expr
+  ;
+
+type nonliteral<xs, constraint extends any.literal = any.literal>
   = [xs] extends [any.literal]
   ? [number] extends [xs] ? constraint
   : [string] extends [xs] ? constraint
   : [boolean] extends [xs] ? constraint
-  : never
-  : never
+  : never.as.nothing
+  : never.close.unmatched_expr
+  ;
+
+type union<xs, constraint = unknown>
+  = [xs] extends [constraint]
+  ? Union.is<xs> extends true ? constraint
+  : never.as.nothing
+  : never.close.unmatched_expr
+  ;
+
+type nonunion<xs, constraint = unknown>
+  = [xs] extends [constraint]
+  ? Union.is<xs> extends true ? never.as.nothing
+  : constraint
+  : never.close.unmatched_expr
   ;
 
 declare namespace Catch {
   export {
-    nonLiteral,
-    nonTuple,
+    literal,
+    nonliteral,
+    nonliteral as nonLiteral,
+
+    tuple,
+    nontuple,
+    nontuple as nonTuple,
+
+    union,
+    nonunion,
+    nonunion as nonUnion,
   }
 }

--- a/src/err/enforce.ts
+++ b/src/err/enforce.ts
@@ -65,8 +65,6 @@ declare namespace impl {
 
 type constrain<invariant, type> = type & invariant
 
-declare function nonObjects<const type extends nonobject<type>>(x: type): type
-
 type check<type, constraint, applied, err> =
   [type] extends [constraint]
   ? ([type] extends [applied] ? unknown : err)

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -32,7 +32,7 @@ export type { Kind } from "./kind/exports"
 export type { traversable, traversal } from "./traversable/exports"
 
 export type { iter } from "./iter/exports"
-export type { mut } from "./mutable/exports"
+export type { mut, mutable } from "./mutable/exports"
 export type { pathsof } from "./paths/exports"
 export type { never } from "./semantic-never/exports"
 export type {

--- a/src/mutable/exports.ts
+++ b/src/mutable/exports.ts
@@ -1,1 +1,15 @@
 export * as mut from "./mutable"
+export {
+  mutable,
+}
+
+import type { any } from "../any-namespace"
+
+type mutable<type>
+  = type extends any.primitive ? type
+  : type extends any.array ? { -readonly [ix in keyof type]: mutable<type[ix]> }
+  : type extends any.object ? { -readonly [ix in keyof type]: mutable<type[ix]> }
+  : type
+  ;
+
+declare function mutable<const type>(type: type): mutable<type>

--- a/src/semantic-never/semantic-never.ts
+++ b/src/semantic-never/semantic-never.ts
@@ -17,16 +17,29 @@ namespace never {
   }
 }
 
+declare namespace as {
+  export type empty<__description extends string = never> = never
+  export type nothing<__description extends string = never> = never
+  export type identity<__description extends string = never> = never
+}
+
 declare namespace never {
   // namespace re-exports
-  export { close }
+  export {
+    as,
+    close,
+  }
   /**
    * TODO: Experiment with using {@link $$.IllegalState `$$.IllegalState`} as a runtime value
    * indicating that an illegal state was reached
    */
   export type illegal_state<__description extends string = never> = never
-  export type as_empty<__description extends string = never> = never
-  export type as_nothing<__description extends string = never> = never
-  export type as_identity<__description extends string = never> = never
   export type not_meant_for_use<__description extends string = never> = never
+
+  /** @deprecated - use {@link as.empty `never.as.empty`} instead */
+  export type as_empty<__description extends string = never> = never
+  /** @deprecated - use {@link as.nothing `never.as.nothing`} instead */
+  export type as_nothing<__description extends string = never> = never
+  /** @deprecated - use {@link as.identity `never.as.identity`} instead */
+  export type as_identity<__description extends string = never> = never
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const ANY_TS_VERSION = "0.36.5" as const
+export const ANY_TS_VERSION = "0.36.6" as const
 export type ANY_TS_VERSION = typeof ANY_TS_VERSION


### PR DESCRIPTION
## changelog
v0.36.6

### new features:
- [feat: adds `mutable` type (recursive)](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)
- [feat: adds `Catch.union`, `Catch.nonunion` types](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)
- [feat: adds `Catch.literal`, `Catch.nonliteral` types](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)

### deprecations:
- [deprecates: `never.as_empty`](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)
- - use `never.as.empty` instead
- [deprecates: `never.as_identity`](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)
- - use `never.as.identity` instead
- [deprecates: `never.as_nothing`](https://github.com/ahrjarrett/any-ts/commit/b127a87336b05fcfacea69594254580c7e7bf5ee)
- - use `never.as.nothing` instead
