### PR TITLE
fix: removes dangling whitespace in `string.snake`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "any-ts",
   "private": false,
-  "version": "0.39.3",
+  "version": "0.39.4",
   "author": {
     "name": "Andrew Jarrett",
     "email": "ahrjarrett@gmail.com",

--- a/src/string/string.spec.ts
+++ b/src/string/string.spec.ts
@@ -89,6 +89,12 @@ declare namespace Spec {
     Internal.takeUntilCaseChangeRec<[], "fbiVanWest">,  //  ["fbi", "Van", "West"]
     Internal.takeUntilCaseChangeRec<[], "fbi_Van_West">,  //  ["fbi", "Van", "West"]
     Internal.takeUntilCaseChangeRec<[], "fbiVan123">,  //  ["fbi", "Van", "West"]
+    Internal.takeUntilCaseChangeRec<[], "FBIVan123">,
+    Internal.takeUntilCaseChangeRec<[], "FBIVan1abc">,
+    Internal.takeUntilCaseChangeRec<[], "123">,
+    Internal.takeUntilCaseChangeRec<[], "FBIVan123AndStuff">,
+    Internal.takeUntilCaseChangeRec<[], "FBIVan123andStuff">,
+    Internal.takeUntilCaseChangeRec<[], "PROPERTY">,
   ]
 
   type takeUntilExclusive = [
@@ -115,12 +121,18 @@ declare namespace Spec {
     string.takeUntilInclusive<"", charset.Lowers>,
   ]
 
-  type __TEST__ = [
+  type snake = [
     // ^?
-    Internal.takeUntilCaseChangeRec<[], "FBIVan123">,
-    Internal.takeUntilCaseChangeRec<[], "FBIVan1abc">,
-    Internal.takeUntilCaseChangeRec<[], "123">,
-    Internal.takeUntilCaseChangeRec<[], "FBIVan123AndStuff">,
-    Internal.takeUntilCaseChangeRec<[], "FBIVan123andStuff">,
+    expect<assert.equal<string.snake<"FBIVan123">, "fbi_van_123">>,
+    expect<assert.equal<string.snake<"FBIVan1abc">, "fbi_van_1_abc">>,
+    expect<assert.equal<string.snake<"123">, "123">>,
+    expect<assert.equal<string.snake<"FBIVan123AndStuff">, "fbi_van_123_and_stuff">>,
+    expect<assert.equal<string.snake<"FBIVan123andStuff">, "fbi_van_123_and_stuff">>,
+    expect<assert.equal<string.snake<"PROPERTY">, "property">>,
+    expect<assert.equal<Internal.snake<"FBIVan123">, "fbi_van_123">>,
+    expect<assert.equal<Internal.snake<"FBIVan1abc">, "fbi_van_1_abc">>,
+    expect<assert.equal<Internal.snake<"123">, "123">>,
+    expect<assert.equal<Internal.snake<"FBIVan123AndStuff">, "fbi_van_123_and_stuff">>,
+    expect<assert.equal<Internal.snake<"FBIVan123andStuff">, "fbi_van_123_and_stuff">>,
   ]
 }

--- a/src/string/string.ts
+++ b/src/string/string.ts
@@ -219,7 +219,7 @@ declare function delimitedCase<delimiter extends check.is.stringLiteral<string, 
   (string: string): Uncapitalize<string>
 }
 
-type snake<type extends any.showable> = Internal.snake<`${type} `>
+type snake<type extends any.showable> = Internal.snake<`${type}`>
 type snakeKey<type extends any.primitive> = type extends any.showable ? snake<type> : type
 type snakeKeys<type extends any.object> = { [ix in keyof type as snakeKey<ix>]: type[ix] }
 type snakeArrayValues<type extends any.showables> = { [ix in keyof type]: snake<type[ix]> }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const ANY_TS_VERSION = "0.39.3" as const
+export const ANY_TS_VERSION = "0.39.4" as const
 export type ANY_TS_VERSION = typeof ANY_TS_VERSION


### PR DESCRIPTION
## changelog

### fixes
- [fix: removes dangling whitespace in string.snake](https://github.com/ahrjarrett/any-ts/commit/717d362e00fa98a2c36b8932c04344ad8825138c) 
