### PR TITLE
feat: adds `Kind.reduce` and `Kind.fold` (suggested by @MajorLift)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "any-ts",
   "private": false,
-  "version": "0.39.5",
+  "version": "0.40.0",
   "author": {
     "name": "Andrew Jarrett",
     "email": "ahrjarrett@gmail.com",

--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -100,7 +100,7 @@ declare namespace any {
   export type list<type extends any.array = any.array> = type
   export type entries<type extends any.array<entry> = any.array<entry>> = type
   export type struct<type extends any_struct = any_struct> = type
-  export type dictionary<type = _> = dict<type>
+  export type dictionary<type = _> = any_dict<type>
   export type enumerable<type extends any_enumerable = any_enumerable> = type
   export type arraylike<type extends any_arraylike = any_arraylike> = type
   export type invertible<type extends any_invertible = any_invertible> = type
@@ -224,30 +224,31 @@ declare namespace any {
   > = subtype
 }
 
-type any_index = keyof never
-type any_nonnullable = {}
-type any_nullable = null | undefined
-type any_type<type extends any_nullable | any_nonnullable = any_nullable | any_nonnullable> = type
-type any_key<type extends string | number = string | number> = type
-type any_scalar = string | number | boolean | null
+export type any_index = keyof never
+export type any_nonnullable = {}
+export type any_nullable = null | undefined
+export type any_type<type extends any_nullable | any_nonnullable = any_nullable | any_nonnullable> = type
+export type any_key<type extends string | number = string | number> = type
+export type any_scalar = string | number | boolean | null
 
-interface dict<type = _> { [ix: keyof never]: type }
-type any_array<type = _> = readonly type[]
+export interface any_dict<type = _> { [ix: keyof never]: type }
+export type any_array<type = _> = readonly type[]
 /** @ts-expect-error */
-interface any_object<type extends object = object> extends id<type> { }
-type any_struct<type = any> = { [ix: string]: type }
-interface any_enumerable<type = unknown> { [ix: number]: type }
-interface any_arraylike<type = unknown> extends any_enumerable<type> { length: number }
-interface any_invertible { [ix: any_key]: any_key }
-type any_field<k extends any_index = any_index, v = unknown> = readonly [key: k, value: v]
-type any_entry<type extends readonly [any_index, unknown] = readonly [any_index, unknown]> = type
-interface any_class<
+export interface any_object<type extends object = object> extends id<type> { }
+export type any_struct<type = any> = { [ix: string]: type }
+export interface any_enumerable<type = unknown> { [ix: number]: type }
+export interface any_arraylike<type = unknown> extends any_enumerable<type> { length: number }
+export interface any_invertible { [ix: any_key]: any_key }
+export type any_field<k extends any_index = any_index, v = unknown> = readonly [key: k, value: v]
+export type any_entry<type extends readonly [any_index, unknown] = readonly [any_index, unknown]> = type
+export interface any_class<
   args extends
   | any.array<any>
   = any.array<any>
 > { new(...arg: args): _ }
-type any_json =
+
+export type any_json =
   | any.scalar
+  | any_dict<any_json>
   | readonly any_json[]
-  | dict<any_json>
   ;

--- a/src/kind/exports.ts
+++ b/src/kind/exports.ts
@@ -8,7 +8,12 @@ export type {
   Negate,
 } from "./extensible"
 
-export type { Kind } from "./kind"
+export type {
+  Kind,
+  Scope,
+  /** @internal */
+  $$,
+} from "./kind"
 
 export type {
   tag,

--- a/src/kind/kind.spec.ts
+++ b/src/kind/kind.spec.ts
@@ -1,7 +1,6 @@
+import type { any } from "../any/exports"
 import type { assert, expect } from "../test/exports"
 import type { Kind } from "./kind"
-
-type evaluate<type> = never | ({ [ix in keyof type]: type[ix] })
 
 declare namespace Spec {
   type _ = unknown
@@ -119,7 +118,35 @@ declare namespace Spec {
       { [-1]: _, 0: s, 1: n, 2: b, 3: s, 4: n, 5: b, 6: s, 7: n, 8: b }
     >>,
   ]
+
+  interface Intercalate<delimiter extends any.showable> extends Kind<[string, string]> {
+    [-1]: this[0] extends "" ? this[1] : `${this[0]}${delimiter}${this[1]}`
+  }
+
+  type reduce = [
+    expect<assert.equal<
+      Kind.apply<Kind.reduce<string>, [
+        f: Intercalate<"::">,
+        xs: ["1", "2", "3"],
+        empty: ""
+      ]>,
+      "1::2::3"
+    >>,
+  ]
+  type fold = [
+    expect<assert.equal<
+      Kind.apply<
+        Kind.fold<string>,
+        [
+          f: Intercalate<", ">,
+          xs: ["1", "2", "3"]
+        ]
+      >,
+      "1, 2, 3"
+    >>,
+  ]
 }
+
 
 // type greatestArity<keys extends keyof Scope, countdown extends Arity = 9>
 //   = countdown extends keys ? countdown

--- a/src/to.ts
+++ b/src/to.ts
@@ -1,14 +1,26 @@
 export { to }
 
+import type { mut } from ".";
 import type { any } from "./any/exports"
 
-namespace to { export const never: never = void 0 as never }
 declare namespace to {
   export type entries<type = any.nonnullable>
     = [keyof type] extends [any.keyof<type, infer key>]
     ? key extends key
     ? any.field<key, type[key]>
     : never
+    : never
+    ;
+
+  export { toString as string }
+  type toString<type extends any.showable> = `${type}`
+
+  export type vector<type> = never | { [ix in Exclude<keyof type, keyof any[]>]: type[ix] }
+  export type keyValuePairs<type, mutable = never>
+    = keyof type extends any.keyof<type, infer key>
+    ? [mutable] extends [never]
+    ? any.array<key extends key ? readonly [key, type[key]] : never>
+    : mut.array<key extends key ? [key, type[key]] : never>
     : never
     ;
 }

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -19,10 +19,10 @@ type nonempty<
   lead extends any.path = any.path
 > = readonly [...lead, last]
 
-type mergeTrees<union> = never.as.identity
-  | [union] extends [any.primitive] ? union :
-  { [ix in union extends union ? keyof union : never.close.distributive]
-    : mergeTrees<union extends any.indexedby<ix> ? union[ix] : never.close.distributive> }
+type merge<t> = never
+  | [t] extends [any.primitive] ? t
+  : { [k in t extends any.object ? keyof t : never]
+    : merge<t extends any.indexedby<k> ? t[k] : never> }
   ;
 
 type shift<xs extends pathable>
@@ -32,7 +32,7 @@ declare namespace Tree {
   export {
     shift,
     fromPaths,
-    mergeTrees as merge,
+    merge,
     pathable,
   }
 
@@ -52,5 +52,4 @@ declare namespace Tree {
       : { [e in Tree.shift<xs> as e[0]]: go.breadthFirst<e[1]> }
       ;
   }
-
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const ANY_TS_VERSION = "0.39.5" as const
+export const ANY_TS_VERSION = "0.40.0" as const
 export type ANY_TS_VERSION = typeof ANY_TS_VERSION


### PR DESCRIPTION
## changelog

### new features
- adds `Kind.reduce` & `Kind.fold` 
  - prior art: [`Reduce` from hkt-toolbelt](https://github.com/poteat/hkt-toolbelt/blob/main/src/list/reduce.ts)
  - [original thread](https://github.com/poteat/hkt-toolbelt/issues/59#issuecomment-2018937609)

### fixes
- exports intermediate types from `any` module
