### PR TITLE
release v0.40.11

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "access": "public",
+  "baseBranch": "main",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
+  "ignore": [],
   "linked": [],
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+  "updateInternalDependencies": "patch"
 }

--- a/.changeset/ninety-cows-bow.md
+++ b/.changeset/ninety-cows-bow.md
@@ -1,0 +1,17 @@
+---
+"any-ts": patch
+---
+
+## features
+adds:
+- `object.filter`
+- `object.filterKeys`
+
+## deprecations
+deprecates: 
+- `any.arrayof` - use `any.arrayOf` instead
+- `any.entriesof` - use `any.entriesOf` instead
+- `any.entryof` - use `any.entryOf` instead
+- `any.keysof` - use `any.keysOf` instead
+- `any.subtypeof` - use `any.subtypeOf` instead
+- `any.indexedby` - use `any.indexedBy` instead

--- a/bin/version.ts
+++ b/bin/version.ts
@@ -101,7 +101,7 @@ const versionTemplate: (version: string) => string
  * published.
  */
 const writeVersion = (v: string): void => {
-  return void (v && writeFile(versionFile)(versionTemplate(v)))
+  return void (v && v.length > 0 && writeFile(versionFile)(versionTemplate(v)))
 }
 
 function commitWorktree(version: string): void {

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Looking for something that we don't ship yet? [Raise an issue](https://github.co
 - [`boolean`](https://github.com/ahrjarrett/any-ts/blob/main/src/boolean/boolean.ts)
 - [`char`](https://github.com/ahrjarrett/any-ts/blob/main/src/string/char.ts)
 - [`empty`](https://github.com/ahrjarrett/any-ts/blob/main/src/empty.ts)
-- [`Kind`](https://github.com/ahrjarrett/any-ts/blob/main/src/kind/kind.ts) (a [higher-kinded type](https://en.wikipedia.org/wiki/Kind_(type_theory)) encoding that is more ergonomic than any other we've found)
+- [`Kind`](https://github.com/ahrjarrett/any-ts/blob/main/src/kind/kind.ts), a simple but powerful [HKT](https://en.wikipedia.org/wiki/Kind_(type_theory)) encoding that supports partial application & re-binding
 - [`integer`](https://github.com/ahrjarrett/any-ts/blob/main/src/number/integer.ts)
 - [`mut`](https://github.com/ahrjarrett/any-ts/blob/main/src/mutable/mutable.ts)
 - [`never`](https://github.com/ahrjarrett/any-ts/blob/main/src/semantic-never/semantic-never.ts), a.k.a. semantic never

--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -81,6 +81,7 @@ declare namespace any {
   export type single<type extends one = one> = type
   export type unary<type extends some.unary = some.unary> = type
   export type two<one = _, two = _> = readonly [_1: one, _2: two]
+  export type pair<left = _, right = _> = readonly [left: left, right: right]
   export type double<type extends two = two> = type
   export type binary<type extends some.binary = some.binary> = type
   export type three<one = _, two = _, three = _> = readonly [_1: one, _2: two, _3: three]

--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -29,12 +29,8 @@ declare namespace any {
   /////////////////////
   /// 🡓🡓 aliases
   export {
-    arrayof as arrayOf,
     dictionary as dict,
-    indexableby as indexableBy,
-    indexedby as indexedBy,
     keyof as keyOf,
-    keysof as keysOf,
   }
   /// 🡑🡑 aliases
   ///////////////////

--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -90,6 +90,7 @@ declare namespace any {
   export type three<one = _, two = _, three = _> = readonly [_1: one, _2: two, _3: three]
   export type triple<type extends three = three> = type
   export type ternary<type extends some.ternary = some.ternary> = type
+  export type record<type extends globalThis.Record<string, _> = globalThis.Record<string, _>> = type
 
   export type predicate<type extends some.predicate = some.predicate> = type
   export type asserts<target = _> = never | some.asserts<any, target>
@@ -129,52 +130,42 @@ declare namespace any {
     = keyof invariant
   > = type
 
-  export type keysof<
+  export type keysOf<
     invariant,
     type extends
     | any.array<keyof invariant>
     = any.array<keyof invariant>
   > = type
 
-  export type propertyof<
+  export type propertyOf<
     invariant,
     type extends
     | any.key & keyof invariant
     = any.key & keyof invariant
   > = type
 
-  /**
-   * @deprecated use {@link propertyof `any.propertyof`} or {@link propertyof `any.propertyOf`} instead
-   */
-  export type showableKeyof<
-    invariant,
-    type extends
-    | any.key & keyof invariant
-    = any.key & keyof invariant
-  > = type
-
-  export type indexof<
+  export type indexOf<
     invariant extends any.array,
     type extends
     | Extract<keyof invariant, `${number}`>
     = Extract<keyof invariant, `${number}`>
   > = type
 
-  export type indexedby<
+  export type indexedBy<
     invariant extends any.index,
     type extends
     | { [ix in invariant]: _ }
     = { [ix in invariant]: _ }
   > = type
 
-  export type indexableby<
+  export type indexableBy<
     invariant extends any.index,
     type extends
     | { [ix in invariant]: any.index }
     = { [ix in invariant]: any.index }
   > = type
 
-  export type pathof<
+  export type pathOf<
     invariant,
     type extends
     | pathsof<invariant>
@@ -188,40 +179,55 @@ declare namespace any {
     = { [ix in invariant[0]]: invariant[1] }
   > = type
 
-  export type arrayof<
+  export type arrayOf<
     invariant,
     type extends
     | any.array<invariant>
     = any.array<invariant>
   > = type
 
-  export type entryof<
+  export type entryOf<
     invariant,
     type extends
     | readonly [any.index, invariant]
     = readonly [any.index, invariant]
   > = type
 
-  export type entriesof<
+  export type entriesOf<
     invariant,
     type extends
     | any.array<readonly [any.index, invariant]>
     = any.array<readonly [any.index, invariant]>
   > = type
 
-  export type fieldof<
+  export type fieldOf<
     invariant,
     type extends
     | to.entries<invariant>
     = to.entries<invariant>
   > = type
 
-  export type subtypeof<
+  export type subtypeOf<
     invariant,
     subtype extends
     | invariant extends invariant ? invariant : never
     = invariant extends invariant ? invariant : never
   > = subtype
+
+
+  export type domainOf<
+    invariant extends some.function,
+    target extends
+    | globalThis.Parameters<invariant>
+    = globalThis.Parameters<invariant>
+  > = target
+
+  export type codomainOf<
+    invariant extends some.function,
+    target extends
+    | globalThis.ReturnType<invariant>
+    = globalThis.ReturnType<invariant>
+  > = target
 }
 
 export type any_index = keyof never
@@ -236,19 +242,20 @@ export type any_array<type = _> = readonly type[]
 /** @ts-expect-error */
 export interface any_object<type extends object = object> extends id<type> { }
 export type any_struct<type = any> = { [ix: string]: type }
-export interface any_enumerable<type = unknown> { [ix: number]: type }
-export interface any_arraylike<type = unknown> extends any_enumerable<type> { length: number }
+export interface any_enumerable<type = _> { [ix: number]: type }
+export interface any_arraylike<type = _> extends any_enumerable<type> { length: number }
 export interface any_invertible { [ix: any_key]: any_key }
-export type any_field<k extends any_index = any_index, v = unknown> = readonly [key: k, value: v]
-export type any_entry<type extends readonly [any_index, unknown] = readonly [any_index, unknown]> = type
+export type any_field<key extends any_index = any_index, value = _> = readonly [key: key, value: value]
+export type any_entry<type extends readonly [any_index, _] = readonly [any_index, _]> = type
 export interface any_class<
   args extends
   | any.array<any>
-  = any.array<any>
-> { new(...arg: args): _ }
+  = any.array<any>,
+  target = _
+> { new(...arg: args): target }
 
 export type any_json =
   | any.scalar
-  | any_dict<any_json>
   | readonly any_json[]
+  | any_dict<any_json>
   ;

--- a/src/err/enforce.ts
+++ b/src/err/enforce.ts
@@ -139,7 +139,7 @@ declare namespace enforce {
 
   type uniqNonNumericIndex<type>
     = [type] extends [any.entries]
-    ? impl.nonnumericIndex<type> extends any.arrayof<any.index, infer numerics>
+    ? impl.nonnumericIndex<type> extends any.arrayOf<any.index, infer numerics>
     ? Err2<"NonNumericIndex", numerics>
     : enforce.uniqueness.ofEntries<type> extends infer dupes
     ? unknown extends dupes ? (unknown)

--- a/src/evaluate/evaluate.ts
+++ b/src/evaluate/evaluate.ts
@@ -1,4 +1,5 @@
 export {
+  eval,
   evaluate,
 }
 
@@ -25,16 +26,42 @@ import type { any } from "../any/exports";
 *  type bababababab = evaluate<A, -1>
 *  //   ^? type bababababab = { b: { a: { b: { a: { b: { a: { b: { a: { b: { a: { b: any } } } } } } } } } } }
 */
-function evaluate<const type>(type: type): evaluate<type, 1>
+function evaluate<const type>(type: type): eval<type>
 function evaluate<const type, maxDepth extends number>(type: type, maxDepth: maxDepth): evaluate<type, maxDepth>
 function evaluate<const type, maxDepth extends number>(type: type, _max?: maxDepth): unknown { return type }
 
-type evaluate<type, maxDepth extends number = 1> = evaluate.go<type, [], maxDepth>
+/** 
+ * {@link eval `eval`} is semantically equivalent to {@link evaluate `evaluate`} with
+ * a hardcoded max-depth of 1.
+ * 
+ * In practice, you should use `eval` when you want a shallow evaluation, because 
+ * TypeScript can make certain optimizations when it knows that an expression does
+ * not contain any sub-expressions that require recursion.
+ * 
+ * @example
+*  import type { eval } from "any-ts"
+* 
+*  interface Abc { abc: Def }
+*  interface Def { def: Ghi }
+*  interface Ghi { ghi: Abc }
+* 
+*  type Purdy = eval<Abc & Def & Ghi>
+*  //   ^? type Purdy = { abc: 123, def: 456, ghi: 789 }
+*/
+type eval<type> = never | ({ [k in keyof type]: type[k] })
+
+/** 
+ * {@link evaluate `evaluate`} "evaluates" an expression.
+ * 
+ * In practice, you should use {@link eval `eval`} when you want a shallow 
+ * evaluation, because TypeScript can make certain optimizations when it 
+ * knows that an expression does not contain any sub-expressions that require recursion.
+ */
+type evaluate<type, maxDepth extends number = 2> = evaluate.go<type, [], maxDepth>
 declare namespace evaluate {
   type go<type, currentDepth extends void[], maxDepth extends number>
     = maxDepth extends currentDepth["length"] ? type
     : type extends any.primitive | any.function ? type
-    : { [ix in keyof type]
-      : go<type[ix], [...currentDepth, void], maxDepth> }
+    : { [ix in keyof type]: go<type[ix], [...currentDepth, void], maxDepth> }
     ;
 }

--- a/src/evaluate/exports.ts
+++ b/src/evaluate/exports.ts
@@ -1,1 +1,1 @@
-export { evaluate } from "./evaluate"
+export type { eval, evaluate } from "./evaluate"

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -9,7 +9,7 @@ export {
 
 export type { any } from "./any/exports"
 export type { some } from "./some"
-export type { } from "./associative/exports"
+export type { object } from "./object/exports"
 export type { boolean } from "./boolean/exports"
 export type { cache } from "./cache/exports"
 export type { evaluate } from "./evaluate/exports"

--- a/src/kind/bind.ts
+++ b/src/kind/bind.ts
@@ -13,9 +13,3 @@ declare namespace Bind {
   type partial<type extends Kind> = globalThis.Omit<type, -1> extends any.subtypeOf<type, infer next> ? next : never
 }
 
-type __Bind__ = [
-  Kind.apply<Bind.two, { 0: "zero" }>,
-  Kind.apply<Bind.two, { 1: "one" }>,
-  Kind.apply<Bind.three, { 2: "two" }>,
-]
-

--- a/src/kind/bind.ts
+++ b/src/kind/bind.ts
@@ -10,7 +10,7 @@ declare namespace Bind {
   interface four<a = _, b = _, c = _, d = _> extends Kind<[a, b, c, d]> { [-1]: Kind<[this[0], this[1], this[2], this[3]]> }
   interface five<a = _, b = _, c = _, d = _, e = _> extends Kind<[a, b, c, d, e]> { [-1]: Kind<[this[0], this[1], this[2], this[3], this[4]]> }
 
-  type partial<type extends Kind> = globalThis.Omit<type, -1> extends any.subtypeof<type, infer next> ? next : never
+  type partial<type extends Kind> = globalThis.Omit<type, -1> extends any.subtypeOf<type, infer next> ? next : never
 }
 
 type __Bind__ = [

--- a/src/kind/kind.ts
+++ b/src/kind/kind.ts
@@ -122,7 +122,17 @@ type kind<params extends nonunion<params> = Scope>
 
 type parseInt<type extends any.index> = `${type & any.key}` extends `${infer x extends number}` ? x : never;
 type structured<type> = never | [type] extends [any.array] ? { [ix in Extract<keyof type, `${number}`> as parseInt<ix>]: type[ix] } : type
-type satisfies<type> = never | ({ [ix in Exclude<keyof type, -1>]+?: type[ix] })
+
+// type satisfies<type> = never | ({ [ix in Exclude<keyof type, -1>]+?: type[ix] })
+type satisfies<fn extends Kind> = never
+  | ([fn] extends [kind<infer scope>]
+    ? unknown extends scope
+    ? { [ix in globalThis.Exclude<keyof fn, -1>]: fn[ix] }
+    : scope
+    : never
+  )
+  ;
+
 
 type inferConstraints<fn extends Kind>
   = fn extends Kind<infer constraints>
@@ -155,7 +165,7 @@ type slots<arity extends Arity> = cached.slots[cached.prev[arity]]
 type Arity = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 interface Scope { 0?: _, 1?: _, 2?: _, 3?: _, 4?: _, 5?: _, 6?: _, 7?: _, 8?: _, 9?: _ }
 
-type bind<fn extends Kind, args extends satisfies<fn>> = never | (fn & structured<args>)
+type bind<fn extends Kind, args extends Partial<satisfies<fn>>> = never | (fn & structured<args>)
 type apply<fn extends Kind, args extends satisfies<fn>> = bind<fn, args>[-1]
 
 type constraintsOf<fn extends Kind, type extends satisfies<fn> = satisfies<fn>> = type

--- a/src/lens/focus.ts
+++ b/src/lens/focus.ts
@@ -144,13 +144,13 @@ declare namespace impl {
 
   type merge<union>
     = { [ix in union extends union ? keyof union : never.close.distributive]
-      : union extends any.indexedby<ix> ? union[ix] : never.close.distributive }
+      : union extends any.indexedBy<ix> ? union[ix] : never.close.distributive }
     ;
 
   type mergeTrees<union> = never.as_identity
     | [union] extends [any.primitive] ? union :
     { [ix in union extends union ? keyof union : never.close.distributive]
-      : impl.mergeTrees<union extends any.indexedby<ix> ? union[ix] : never.close.distributive> }
+      : impl.mergeTrees<union extends any.indexedBy<ix> ? union[ix] : never.close.distributive> }
     ;
 
   type joinLeft<left, right> = never.as_identity

--- a/src/lens/tree.ts
+++ b/src/lens/tree.ts
@@ -42,7 +42,7 @@ type joinRight<left, right> = never.as_identity
   }
 
 type fromPaths<delimiter extends any.showable, type extends any.array<any.string>>
-  = splitPaths<type, delimiter> extends any.arrayof<any.array<string>, infer split>
+  = splitPaths<type, delimiter> extends any.arrayOf<any.array<string>, infer split>
   ? { [ix in keyof split]: traversable.unfold<{}, split[ix]> } extends any.list<infer trees>
   ? impl.joinTrees<unknown, trees>
   : never.close.inline_var<"trees">

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,8 +1,88 @@
-export {
-  object_ as object
+import type { any } from "./any/exports"
+import type { some } from "./some"
+import type { eval } from "./evaluate/exports"
+
+export declare namespace object {
+  type filter = {
+    <A, B>(guard: any.typeguard<A, B>): <const T extends any.dict<A>>(object: T) => filter.values<T, B>
+    <A>(predicate: some.predicate<A>): <const T extends any.dict<A>>(object: T) => filter.values<T, A>
+    <A, B, const T extends any.dict<A>>(object: T, guard: any.typeguard<A, B>): filter.values<T, B>
+    <A, const T extends any.dict<A>>(object: T, predicate: some.predicate<A>,): filter.values<T, A>
+  }
+
+  type filterKeys = {
+    <A extends any.index, B extends any.index>(guard: any.typeguard<A, B>): <const T extends any.indexedBy<A>>(object: T) => filter.keys<T, B>
+    <A extends any.index>(predicate: some.predicate<A>): <const T extends any.indexedBy<A>>(object: T) => filter.keys<T, A>
+    <A extends any.index, B extends any.index, const T extends any.indexedBy<A>>(object: T, guard: any.typeguard<A, B>): filter.keys<T, B>
+    <A extends any.index, const T extends any.indexedBy<A>>(object: T, predicate: some.predicate<A>,): filter.keys<T, A>
+  }
 }
 
-type id<type> = type
+declare namespace filter {
+  type keys<t, bound extends any.index> = never |
+    eval<
+      & filter.keys.satisfy<t, bound>
+      & filter.keys.partiallySatisfy<t, bound>
+      & filter.keys.mightSatisfy<t, bound>
+    >
 
-interface object_ extends id<object> { }
-declare const object_: object_
+  namespace keys {
+    type satisfy<t, bound extends any.index> = never |
+      { -readonly [k in keyof t as filter.allSatisfy<k, bound> extends true ? k : never]: t[k] }
+    type partiallySatisfy<t, bound extends any.index> = never |
+      { -readonly [k in keyof t as filter.partiallySatisfy<k, bound> extends true ? k : never]: t[k] }
+    type mightSatisfy<t, bound extends any.index> = never |
+      { -readonly [k in keyof t as filter.mightSatisfy<k, bound> extends true ? k : never]: t[k] }
+  }
+
+  type values<t, bound> = never |
+    eval<
+      & filter.values.satisfy<t, bound>
+      & filter.values.partiallySatisfy<t, bound>
+      & filter.values.mightSatisfy<t, bound>
+    >
+
+  namespace values {
+    type satisfy<t, bound> = never |
+      { -readonly [k in keyof t as filter.allSatisfy<t[k], bound> extends true ? k : never]: t[k] }
+    type partiallySatisfy<t, bound> = never |
+      { -readonly [k in keyof t as filter.partiallySatisfy<t[k], bound> extends true ? k : never]+?: t[k] }
+    type mightSatisfy<t, bound> = never |
+      { -readonly [k in keyof t as filter.mightSatisfy<t[k], bound> extends true ? k : never]+?: filter.cast<t[k], bound> }
+  }
+
+  type cast<type, invariant, distribute = never>
+    = [distribute] extends [never]
+    ? (type extends invariant ? type : never) extends infer narrow
+    ? [narrow] extends [never] ? invariant
+    : narrow
+    : never
+    : type extends type ? filter.cast<type, invariant, never>
+    : never
+    ;
+
+  type allSatisfy<t, bound>
+    = (
+      bound extends bound
+      ? (t extends t & bound ? t : never) extends infer out
+      ? out
+      : never
+      : never
+    ) extends infer out
+    ? [t, out] extends [out, t] ? true
+    : false
+    : never
+    ;
+
+  type partiallySatisfy<t, bound>
+    = filter.allSatisfy<t, bound> extends true ? false
+    : [bound extends bound ? (t extends bound ? true : never) : never] extends [never] ? false
+    : true
+    ;
+
+  type mightSatisfy<t, bound>
+    = [t] extends [bound] ? never
+    : [t extends t ? (bound extends t ? true : never) : never] extends [never] ? false
+    : true
+    ;
+}

--- a/src/object/exports.ts
+++ b/src/object/exports.ts
@@ -1,0 +1,1 @@
+export type { object } from "./object"

--- a/src/object/object.ts
+++ b/src/object/object.ts
@@ -1,6 +1,6 @@
-import type { any } from "./any/exports"
-import type { some } from "./some"
-import type { eval } from "./evaluate/exports"
+import type { any } from "../any/exports"
+import type { some } from "../some"
+import type { eval } from "../evaluate/exports"
 
 export declare namespace object {
   type filter = {

--- a/src/paths/paths.ts
+++ b/src/paths/paths.ts
@@ -11,7 +11,7 @@ type isOptional<key extends keyof type, type>
 
 type pathsof<type>
   = Path.go<type, []> extends
-  | any.two<any, any.arrayof<Path.propWithMeta, infer path>>
+  | any.two<any, any.arrayOf<Path.propWithMeta, infer path>>
   ? { [ix in keyof path]: path[ix] extends
     | any.two<infer segment, infer meta>
     ? meta extends typeof Path.Meta.Optional
@@ -41,7 +41,7 @@ declare namespace Path {
 
   export type array<type extends any.array, path extends any.array<Path.propWithMeta>>
     = number extends type["length"] ? Path.go<type[number], [...path, [𝐤𝐞𝐲: number, 𝐦𝐞𝐭𝐚: typeof Meta.Required]]>
-    : any.indexof<type> extends infer ix
+    : any.indexOf<type> extends infer ix
     ? ix extends keyof type
     ? isOptional<ix, type> extends true
     ? Path.go<Exclude<type[ix], undefined>, [...path, [𝐤𝐞𝐲: ix, 𝐦𝐞𝐭𝐚: typeof Meta.Optional]]>

--- a/src/show/associative.ts
+++ b/src/show/associative.ts
@@ -51,7 +51,7 @@ type index<acc extends any.array, type extends { [len$]: number }>
   = acc["length"] extends type[len$ & keyof type] ? acc
   : index<[
     ...acc,
-    Extract<type, any.indexedby<acc["length"]>>[acc["length"]]],
+    Extract<type, any.indexedBy<acc["length"]>>[acc["length"]]],
     type
   >
   ;
@@ -120,22 +120,22 @@ declare namespace impl {
 
 namespace impl {
   const assoc_
-    : new < const ns extends any.object, const ord extends any.indexedby<len$>>(named: ns, order: ord) => ns & ord
+    : new < const ns extends any.object, const ord extends any.indexedBy<len$>>(named: ns, order: ord) => ns & ord
     = class {
-      constructor(named: any.object, order: any.indexedby<len$>) {
+      constructor(named: any.object, order: any.indexedBy<len$>) {
         Object.assign(this, order, named);
       }
     } as never
   // @ts-expect-error - internal use only
   export class assoc<
     const named extends any.object,
-    const order extends any.indexedby<len$>
+    const order extends any.indexedBy<len$>
   > extends assoc_<named, order> { }
 }
 
 class assoc<
   tag extends Tag,
-  const named extends any.object, order extends any.indexedby<len$>
+  const named extends any.object, order extends any.indexedBy<len$>
 >
   extends impl.assoc<{ [tag$]: tag } & named, order>
   implements Tagged<tag> {

--- a/src/some.ts
+++ b/src/some.ts
@@ -2,6 +2,7 @@ export type { some }
 
 import type { any } from "./any/exports"
 import type { never } from "./semantic-never/exports"
+import type { _ } from "./util"
 
 import type { to } from "./to"
 
@@ -29,40 +30,40 @@ declare namespace distributive {
 }
 
 
-interface fn<args extends any.array<any> = any.array<any>, returns = unknown> { (...arg: args): returns }
+interface fn<dom extends any.array<any> = any.array<any>, cod = _> { (...arg: dom): cod }
 
 interface predicate<type = any> { (u: type): boolean }
 
 type guard<target = never> = never | typeguard<any, target>
-type typeguard<source = any, target = unknown> = never | typePredicate<[source, target]>
+type typeguard<source = any, target = _> = never | typePredicate<[source, target]>
 type typePredicate<
   map extends
-  | readonly [source: unknown, target: unknown]
-  = readonly [source: any, target: unknown]
+  | readonly [source: _, target: _]
+  = readonly [source: any, target: _]
 > = never | ((u: map[0]) => u is map[1])
 
-type asserts<source = any, target = unknown> = never | assertion<[source, target]>
+type asserts<source = any, target = _> = never | assertion<[source, target]>
 type assertion<
   map extends
-  | readonly [source: unknown, target: unknown]
-  = readonly [source: any, target: unknown]
+  | readonly [source: _, target: _]
+  = readonly [source: any, target: _]
 > = never | { (u: map[0]): asserts u is map[1] }
 
-type arrayof<
+type arrayOf<
   invariant,
   type extends
   | any.array<invariant>
   = any.array<invariant>
 > = type
 
-type fieldof<
+type fieldOf<
   invariant,
   type extends
   | to.entries<invariant>
   = to.entries<invariant>
 > = type
 
-type subtypeof<
+type subtypeOf<
   invariant,
   subtype extends
   | invariant extends invariant ? invariant : never
@@ -80,107 +81,116 @@ interface predicate<type> { (x: type): boolean }
 
 
 /**
- * The {@link some `some`} namespace is the dual of {@link any `any`}.
+ * {@link some `some`} is {@link any `any`}'s {@link https://en.wikipedia.org/wiki/Duality_(mathematics) dual}.
  * 
- * Whereas the {@link any `any`} namespace is analogous to 
+ * Explanation:
+ * 
+ * If {@link any `any`} is analogous to 
  * {@link https://en.wikipedia.org/wiki/Universal_quantification universal quantification}
- * (read: "for all"), {@link some `some`} is more closely related to 
+ * (that is, _for all_), then {@link some `some`} corresponds to 
  * {@link https://en.wikipedia.org/wiki/Existential_quantification _existential_ quantification}
- * (read: "there exists").
+ * (that is, _there exists_).
  */
 declare namespace some {
-  // aliased exports
   export {
-    /** {@link arrayof `some.arrayof`} @external */
-    arrayof,
-    /** {@link arrayof `some.arrayOf`} @external */
-    arrayof as arrayOf,
     /** {@link fn `some.function`} @external */
     fn as function,
-    /** {@link fieldof `some.fieldof`} @external */
-    fieldof,
-    /** {@link fieldof `some.fieldOf`} @external */
-    fieldof as fieldOf,
-    /** {@link subtypeof `some.subtypeof`} @external */
-    subtypeof,
-    /** {@link subtypeof `some.subtypeOf`} @external */
-    subtypeof as subtypeOf,
   }
 
   // direct exports
   export {
+    /** {@link arrayOf `some.arrayOf`} @external */
+    arrayOf,
     /** {@link assertion `some.assertion`} @external */
     assertion,
     /** {@link asserts `some.asserts`} @external */
     asserts,
     /** {@link binary `some.binary`} @external */
     binary,
+    /** {@link entryOf `some.entryOf`} @external */
+    entryOf,
     /** {@link field `some.field`} @external */
     field,
+    /** {@link fieldOf `some.fieldOf`} @external */
+    fieldOf,
     /** {@link guard `some.guard`} @external */
     guard,
+    /** {@link keyof `some.keyof`} @external */
+    keyof,
     /** {@link named `some.named`} @external */
     named,
     /** {@link predicate `some.predicate`} @external */
     predicate,
     /** {@link record `some.record`} @external */
     record,
+    /** {@link subtypeOf `some.subtypeOf`} @external */
+    subtypeOf,
     /** {@link ternary `some.ternary`} @external */
     ternary,
     /** {@link typeguard `some.typeguard`} @external */
     typeguard,
     /** {@link unary `some.unary`} @external */
     unary,
+    /** {@link valueOf `some.valueOf`} @external */
+    valueOf,
+    /** {@link variadic `some.variadic`} @external */
+    variadic,
   }
-
 
   /** {@link unary `some.unary`} @external */
   interface unary<
-    out = unknown,
-    arg = any
-  > { (_: arg): out }
+    returns = _,
+    accepts = any
+  > { (x: accepts): returns }
 
   /** {@link binary `some.binary`} @external */
   interface binary<
-    out = unknown,
-    arg_0 = any,
-    arg_1 = any
-  > { (_0: arg_0, _1: arg_1): out }
+    returns = _,
+    x = any,
+    y = any
+  > { (x: x, y: y): returns }
 
   /** {@link ternary `some.ternary`} @external */
   interface ternary<
-    out = unknown,
-    arg_0 = any,
-    arg_1 = any,
-    arg_2 = any
-  > { (_0: arg_0, _1: arg_1, _2: arg_2): out }
+    out = _,
+    a = any,
+    b = any,
+    c = any
+  > { (x: a, y: b, z: c): out }
+
+  /** {@link variadic `some.variadic`} @external */
+  interface variadic<
+    returns = _,
+    accepts extends any.array<any> = any.array<any>
+  > { (...args: accepts): returns }
 
   /** {@link field `some.field`} @external */
-  type field<key extends any.index = any.index, value = unknown> = any.field<key, value>
+  type field<key extends any.index = any.index, value = _> = any.field<key, value>
 
   /** {@link record `some.record`} @external */
   type record<
     key extends
     | any.index
     = any.key,
-    value = unknown
+    value = _
   > = globalThis.Record<key, value>
 
-  export type entryof<
-    invariant extends any.object,
-    type extends
-    | distributive.entryof<invariant>
-    = distributive.entryof<invariant>
-  > = type
-
-  export type keyof<
+  /** {@link record `some.record`} @external */
+  type keyof<
     invariant,
     type extends
     | distributive.keyof<invariant>
     = distributive.keyof<invariant>
   > = type
 
-  export type valueof<
+  type entryOf<
+    invariant extends any.object,
+    type extends
+    | distributive.entryof<invariant>
+    = distributive.entryof<invariant>
+  > = type
+
+  type valueOf<
     invariant,
     type extends
     | distributive.values<invariant>

--- a/src/string/_internal.ts
+++ b/src/string/_internal.ts
@@ -238,7 +238,7 @@ type snake<text extends string>
   ;
 
 type pascal<type extends string>
-  = char.splitOnChar<delimitedCase<type, " ">, " "> extends any.arrayof<string, infer xs>
+  = char.splitOnChar<delimitedCase<type, " ">, " "> extends any.arrayOf<string, infer xs>
   ? join<{ [ix in keyof xs]: globalThis.Capitalize<globalThis.Lowercase<xs[ix]>> }>
   : never
   ;

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -22,7 +22,7 @@ type nonempty<
 type merge<t> = never
   | [t] extends [any.primitive] ? t
   : { [k in t extends any.object ? keyof t : never]
-    : merge<t extends any.indexedby<k> ? t[k] : never> }
+    : merge<t extends any.indexedBy<k> ? t[k] : never> }
   ;
 
 type shift<xs extends pathable>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from "vitest/config"
-
-export default defineConfig({
-  test: {
-    globalSetup: "vitest.setup.ts"
-  }
-
-})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,0 @@
-import * as at from "@arktype/attest"
-
-export const setup = () => at.setup({})
-
-export const teardown = at.cleanup


### PR DESCRIPTION
## changelog

### new features
adds:
- `object.filter`
- `object.filterKeys`

### deprecations
deprecates: 
- `any.arrayof` - use `any.arrayOf` instead
- `any.entriesof` - use `any.entriesOf` instead
- `any.entryof` - use `any.entryOf` instead
- `any.keysof` - use `any.keysOf` instead
- `any.subtypeof` - use `any.subtypeOf` instead
- `any.indexedby` - use `any.indexedBy` instead