### PR TITLE
fix: moves `array` module declarations into the `array` namespace proper

### DIFF
--- a/.changeset/dry-bugs-brake.md
+++ b/.changeset/dry-bugs-brake.md
@@ -1,0 +1,5 @@
+---
+"any-ts": patch
+---
+
+fix: moves `array` member declar… Andrew Jarrett 1 minute

--- a/src/array/array.ts
+++ b/src/array/array.ts
@@ -24,6 +24,8 @@ export declare namespace array {
     finiteOf,
     head,
     heads,
+    last,
+    lead,
     nonfinite,
     nonfiniteOf,
     snd,
@@ -39,6 +41,34 @@ export declare namespace array {
     // types containing types
     tupleN,
   }
+
+  type finite<xs> = check.is.tuple<xs, any.array, "hush">
+  type finiteOf<xs, invariant extends any.array> = check.is.tuple<xs, invariant, "hush">
+  type nonfinite<xs>
+    = never | ([xs] extends [any.array] ? [number] extends [xs["length"]] ? any.array : never : never)
+  type nonfiniteOf<xs, invariant extends any.array>
+    = never | ([xs] extends [any.array] ? [number] extends [xs["length"]] ? invariant : never : never)
+  /** {@link fst `array.fst`} is an alias for {@link head `array.head`} */
+
+  type fst<xs extends any.array> = never | head<xs>
+  /** {@link head `array.head`} returns just the _first_ element of an array */
+  type head<xs extends any.array>
+    = [xs] extends [nonempty.array<infer head, any>] ? head : (undefined | xs[number])
+  /** {@link heads `array.heads`} returns just the _first_ item of _every_ element of a matrix (an array of arrays) */
+  type heads<xss extends any.array<any.array>> = never | { [ix in keyof xss]: xss[ix][0] }
+  /** {@link snd `array.snd`} returns just the _second_ element of an array */
+  type snd<xs extends any.array> = never | head<tail<xs>>
+  /** {@link snds `array.snds`} returns just the _second_ item of _every_ element of a matrix (an array of arrays) */
+  type snds<xss extends any.array<any.array>> = never | { [ix in keyof xss]: xss[ix][1] }
+  /** {@link tail `array.tail`} returns every element _but_ the _first_ element of an array */
+  type tail<xs extends any.array> = xs extends [any, ...infer tail] ? tail : never
+  /** {@link tail `array.tail`} returns every element _but_ the _first_ element of _every_ element of a matrix (an array of arrays) */
+  type tails<xss extends any.array<any.array>> = never | { [ix in keyof xss]: tail<xss[ix]> }
+
+  /** {@link last `array.last`} returns _just_ every element _but_ the _last_ element of an array */
+  type last<xs extends any.array> = xs extends [infer last, any] ? last : never
+  /** {@link lead `array.lead`} returns every element _but_ the _last_ element of an array */
+  type lead<xs extends any.array> = xs extends [...infer lead, any] ? lead : never
 }
 
 export declare namespace nonemptyArray {
@@ -65,26 +95,3 @@ export declare namespace nonemptyArray {
     : never
     : never
 }
-
-type finite<xs> = check.is.tuple<xs, any.array, "hush">
-type finiteOf<xs, invariant extends any.array> = check.is.tuple<xs, invariant, "hush">
-type nonfinite<xs>
-  = never | ([xs] extends [any.array] ? [number] extends [xs["length"]] ? any.array : never : never)
-type nonfiniteOf<xs, invariant extends any.array>
-  = never | ([xs] extends [any.array] ? [number] extends [xs["length"]] ? invariant : never : never)
-
-/** 
- * {@link fst `array.fst`} is an alias for {@link head `array.head`} 
- */
-type fst<xs extends any.array> = never | head<xs>
-
-type head<xs extends any.array>
-  = [xs] extends [nonempty.array<infer head, any>] ? head : (undefined | xs[number])
-
-type heads<xss extends any.array<any.array>> = never | { [ix in keyof xss]: xss[ix][0] }
-
-type snd<xs extends any.array> = never | head<tail<xs>>
-type snds<xss extends any.array<any.array>> = never | { [ix in keyof xss]: xss[ix][1] }
-
-type tail<xs extends any.array> = xs extends [any, ...infer tail] ? tail : never
-type tails<xss extends any.array<any.array>> = never | { [ix in keyof xss]: tail<xss[ix]> }


### PR DESCRIPTION
This allows us to not have to worry about clashes with other types with the same name (collisions are handled by tsc by appending `$n` to the end of the type name, which harms readability for users
