### PR TITLE
feat: merges `traversable` and `traversal` into `Tree`

### DIFF
--- a/.changeset/hungry-knives-bathe.md
+++ b/.changeset/hungry-knives-bathe.md
@@ -1,0 +1,5 @@
+---
+"any-ts": minor
+---
+
+feat: merges traversable and traversal into Tree

--- a/.changeset/small-suits-smash.md
+++ b/.changeset/small-suits-smash.md
@@ -1,0 +1,5 @@
+---
+"any-ts": patch
+---
+
+fix: uses import.meta.url instead of \_\_dirname

--- a/bin/version.ts
+++ b/bin/version.ts
@@ -41,7 +41,9 @@ const path
     return (path.endsWith("/") ? path.slice(0, -1) : path) as never
   }
 
-const versionFile = path(Path.resolve(__dirname, ".."), "src", "version.ts")
+const dirname = globalThis.__dirname ?? import.meta.url
+
+const versionFile = path(Path.resolve(dirname, ".."), "src", "version.ts")
 
 declare namespace Cause {
   interface PathNotFound<path extends string = string> {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/ahrjarrett/any-ts.git"
   },
-  "packageManager": "pnpm@8.15.6",
+  "packageManager": "pnpm@9.1.0",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/src/traversable/traversable.ts
+++ b/src/traversable/traversable.ts
@@ -1,14 +1,18 @@
 export {
+  /** @deprecated use {@link Tree `Tree`} instead */
   traversable,
+  /** @deprecated use {@link Tree `Tree`} instead */
   traversal,
 }
 
 import type { any } from "../any/exports.js"
 import type { empty, nonempty } from "../empty.js"
+import type { Tree } from "../tree/exports.js"
 
 import type { never } from "../never/exports.js"
 
 declare namespace impl {
+  /** @deprecated use {@link Tree.unfold `Tree.unfold`} instead */
   type unfold<path extends any.path, leaf = unknown>
     = path extends empty.array ? leaf
     : path extends nonempty.pathLeft<infer init, infer last>
@@ -17,6 +21,7 @@ declare namespace impl {
     ;
 }
 
+/** @deprecated use {@link Tree.unfold `Tree.unfold`} instead */
 type unfold<leaf, path extends any.path> = impl.unfold<path, leaf>
 
 /** 
@@ -51,6 +56,8 @@ type unfold<leaf, path extends any.path> = impl.unfold<path, leaf>
  *     blob 
  *   } // ^? const blob: { xyz: "1223" } & { abc: { def: { ghi: unknown } } }
  */
+
+/** @deprecated use {@link Tree.traversableBy `Tree.traversableBy`} instead */
 type by<
   invariant extends any.path,
   type extends
@@ -59,15 +66,24 @@ type by<
 >
   = type
 
+/** @deprecated use {@link Tree `Tree`} instead */
 declare namespace traversable {
   export {
     by,
     unfold,
   }
+
+  /** @deprecated use {@link Tree.unfold `Tree.unfold`} instead */
+  type unfold<path extends any.path, leaf = unknown>
+    = path extends empty.array ? leaf
+    : path extends nonempty.pathLeft<infer init, infer last>
+    ? unfold<init, any.named<[last: last, leaf: leaf]>>
+    : never
+    ;
 }
 
-namespace traversal { export const never: never = void 0 as never }
 declare namespace traversal {
+  /** @deprecated use {@link Tree.traversal `Tree.traversal`} instead */
   type of<
     tree,
     path extends any.array<any.index>,

--- a/src/tree/tree.spec.ts
+++ b/src/tree/tree.spec.ts
@@ -1,77 +1,143 @@
 import type { Tree } from "./tree.js"
 
 import type { any } from "../any/exports.js"
-import type { empty, nonempty } from "../empty.js"
-import type { never } from "../never/exports.js"
+import { assert, expect } from "../test/exports.js"
 
-declare namespace Err {
-  const DepthFirstExpectedNonUnion: "Error: `go.depthFirst` expected a non-union argument for `path`; distribute `path` _outside_ of `go.depthFirst`, otherwise you will lose structure"
+declare namespace Tree_merge {
+  type $returnType = [
+    // ^?
+    expect<assert.equal<
+      Tree.merge<
+        | { a: { b: { c: 1 }, d: 2 }, e: 3 }
+        | { a: { b: { f: 4 }, g: 5, h: 6 }, i: { j: 7, k: { l: 8 } } }
+        | { a: { m: { n: 9 }, o: 10, p: 11, q: { r: 12, s: 13 } } }
+        | { i: { t: 14 }, u: 15, v: { w: 16, x: { y: 17, z: 18 } } }
+      >,
+      {
+        a: {
+          b: {
+            c: 1,
+            f: 4
+          },
+          d: 2,
+          g: 5,
+          h: 6,
+          m: { n: 9 },
+          o: 10,
+          p: 11,
+          q: {
+            r: 12,
+            s: 13
+          }
+        },
+        e: 3,
+        i: {
+          j: 7,
+          k: {
+            l: 8
+          },
+          t: 14
+        },
+        u: 15,
+        v: {
+          w: 16,
+          x: {
+            y: 17,
+            z: 18
+          }
+        }
+      }
+    >>,
+  ]
 }
 
-type depthFirst<
-  leaf,
-  path extends any.path,
-> = [path] extends [empty.path] ? leaf
-  : [path] extends [nonempty.pathLeft<infer init, infer last>]
-  ? depthFirst<{ [ix in last]: leaf }, init>
-  : never.close.inline_var<"init" | "last">
-  ;
+declare namespace Tree_unfold {
+  type $returnType = [
+    // ^?
+    expect<assert.equal<Tree.unfold<["a", "b", "c"]>, { a: { b: { c: unknown } } }>>,
+    expect<assert.equal<Tree.unfold<["a", "b", "c"], [0, 1]>, { a: { b: { c: [0, 1] } } }>>,
+  ]
+}
 
-type unfoldDepthFirst<path extends any.path, leaf>
-  = [path] extends [empty.path] ? leaf
-  : [path] extends nonempty.pathLeft<infer init, infer last>
-  ? unfoldDepthFirst<init, { [ix in last]: leaf }>
-  : never.close.inline_var<"init" | "last">
-  ;
+declare namespace Tree_fromPaths {
+  const paths: [
+    [_1: "abc", _2: "def", _3: "ghi", LEAF: "xyz"],
+    [_1: "abc", _2: "jkl", LEAF: "mno"],
+    [_1: 123, _2: 8, LEAF: [1, 2, 3]],
+    [_1: 123, _2: 456, LEAF: 789],
+    [_1: "abc", _2: "def", _3: "pqr", _4: "stu", LEAF: ["z"]],
+  ]
 
-type fromPaths<paths extends Tree.pathable | any.array<Tree.pathable>>
-  = (paths extends Tree.pathable ? paths : paths[number]) extends Tree.pathable<infer p>
-  ? (p extends Tree.nonempty<infer leaf, infer init> ? [leaf: leaf, init: init] : "BOB") extends infer out
-  ? [out] extends [[any, any.path]] ? depthFirst<out[0], out[1]>
-  : never
-  // unfoldDepthFirst<init, leaf>
-  // [paths] extends [nonemptyPath<infer leaf, infer init>] ? unfoldDepthFirst<init, leaf>
-  : [FALLTHROUGH1: paths]
-  : [FALLTHROUGH2: paths]
-  ;
+  type $propertyTests = [
+    // ^?
+    expect<assert.equal<
+      /** 
+       * _equivalence_: calling `fromPaths` with a matrix (2d-array) 
+       * vs. a union of arrays results in the same behavior
+       */
+      Tree.fromPaths<typeof paths>,
+      Tree.fromPaths<typeof paths[number]>
+    >>
+  ]
 
+  type $returnType = [
+    // ^?
+    expect<assert.equal<
+      Tree.fromPaths<typeof paths>,
+      {
+        abc: {
+          def: {
+            ghi: "xyz",
+            pqr: {
+              stu: ["z"]
+            }
+          },
+          jkl: "mno"
+        },
+        123: {
+          8: [1, 2, 3],
+          456: 789
+        }
+      }
+    >>,
+  ]
+}
 
-type __fromPaths__ = [
-  fromPaths<[
-    ["abc", "def", "ghi", "xyz"],
-    ["abc", "jkl", "mno"],
-    [123, 8],
-    [123, 456, 789],
-    ["abc", "def", "pqr", "stu", ["z"]],
-  ]>,
-]
+declare namespace Tree_shift {
+  type $returnType = [
+    // ^?
+    expect<assert.equal<Tree.shift<[]>, never>>,
+    expect<assert.equal<Tree.shift<[1]>, any.pair<1, []>>>,
+    expect<assert.equal<Tree.shift<[1, "abc"]>, any.pair<1, ["abc"]>>>,
+    expect<assert.equal<Tree.shift<["def", "ghi"]>, any.pair<"def", ["ghi"]>>>,
+    expect<assert.equal<Tree.shift<["def", "ghi", "jkl"]>, any.pair<"def", ["ghi", "jkl"]>>>,
+  ]
+}
 
-type __Tree_fromPaths__ = [
-  // ^?
-  Tree.fromPaths<[
-    ["abc", "def", "ghi", "xyz"],
-    ["abc", "jkl", "mno"],
-    [123, 8],
-    [123, 456, 789],
-    ["abc", "def", "pqr", "stu", ["z"]],
-  ][number]>,
-  Tree.fromPaths<[
-    ["abc", "def", "ghi", "xyz"],
-    ["abc", "jkl", "mno"],
-    [123, 8],
-    [123, 456, 789],
-    ["abc", "def", "pqr", "stu", ["z"]],
-  ]>,
-]
+declare namespace Tree_traversableBy {
+  type input = { a: { b: { c: { d: 2, e: 3 }, f: 4 }, g: 5 }, h: 6 }
 
-type __go_depthFirst__ = [
-  depthFirst<4, [1, 2, 3]>,
-]
+  type $returnType = [
+    // ^?
+    expect<assert.equal<
+      Tree.traversableBy<[1, 2, 3]>,
+      { 1: { 2: { 3: {} } } }
+    >>,
 
-type __branch__ = [
-  Tree.shift<[]>,
-  Tree.shift<[1]>,
-  Tree.shift<[1, "abc"]>,
-  Tree.shift<["def", "ghi"]>,
-  Tree.shift<["def", "ghi", "jkl"]>,
-]
+    expect<assert.equal<
+      input extends
+      | Tree.traversableBy<["a", "b", "c", "d"], infer out>
+      ? out["a"]["b"]["c"]["d"]
+      : never,
+      2
+    >>
+  ]
+}
+
+declare namespace Tree_traversal {
+  /** TODO: write more tests */
+  type $returnType = [
+    // ^?
+    expect<assert.equal<Tree.traversal<{ a: { b: { c: 3 }, d: 4 } }, ["a", "b", "c"]>, 3>>
+  ]
+}

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -1,56 +1,207 @@
 export type {
   Tree,
-  // pathable,
-  // nonempty,
 }
 
 import type { any } from "../any/exports.js"
-import type { empty } from "../empty.js"
+import type { empty, nonempty } from "../empty.js"
+
 
 declare namespace Tree {
   export {
-    shift,
     fromPaths,
     merge,
-    pathable,
     nonempty,
+    pathable,
+    pathway,
+    shift,
+    traversableBy,
+    traversal,
+    unfold,
   }
 
+  /** 
+   * {@link pathway `Tree.pathway`} is an array of indices that terminates in any non-nullable value.
+   * 
+   * @example
+   *  //////////
+   *  /// ok
+   *  const ex_01 = [{}] satisfies Tree.pathway                                  // ✅
+   *  const ex_02 = [[]] satisfies Tree.pathway                                  // ✅
+   *  const ex_03 = ["a", "b", "c", [1, 2, 3]] satisfies Tree.pathway            // ✅
+   *  const ex_04 = [1, 2, 3, { x: "a", y: "b", z: "c" }] satisfies Tree.pathway // ✅
+   *  //////////
+   *  /// err
+   *  const ex_05 = [] satisfies Tree.pathway                          // 🚫 TypeError
+   *  const ex_06 = ["a", "b", "c", null] satisfies Tree.pathway       // 🚫 TypeError
+   *  const ex_07 = ["a", "b", "c", undefined]  satisfies Tree.pathway // 🚫 TypeError
+   */
+  type pathway = readonly [...any.path, {}]
+
+  /**
+   * {@link pathable `Tree.pathable`} is similar to {@link pathway `Tree.pathway`},
+   * with two notable differences:
+   * 
+   * 1. {@link pathable `Tree.pathable`} admits an empty array
+   * 2. {@link pathable `Tree.pathable`} is a type constructor, whereas
+   *    {@link pathway `Tree.pathway`} is nullary
+   * 
+   * @example
+   *  //////////
+   *  /// ok
+   *  type ex_01 = Tree.pathable<[]>                            // ✅ => []
+   *  type ex_02 = Tree.pathable<[{}]>                          // ✅ => [{}]
+   *  type ex_03 = Tree.pathable<[[]]>                          // ✅ => [[]]
+   *  type ex_04 = Tree.pathable<["a", "b", "c", [x: 1, y: 2]]> // ✅ => ["a", "b", "c", [1, 2]]
+   *  type ex_05 = Tree.pathable<[1, 2, 3, { xyz: 4 }]>         // ✅ => [1, 2, 3, { xyz: 4 }]
+   *  //////////
+   *  /// err
+   *  type ex_06 = Tree.pathable<["a", null]>       // 🚫 Type in position 1 [...] is not assignable to type '{}'
+   *  type ex_07 = Tree.pathable<[1, 2, undefined]> // 🚫 Type [...] in position 2 is not assignable to type '{}'
+   */
   type pathable<
     type extends
-    | empty.path | nonempty
-    = empty.path | nonempty
+    | empty.path | pathway
+    = empty.path | pathway
   > = type
 
-  type nonempty<
-    last = any.nonnullable,
-    lead extends any.path = any.path
-  > = readonly [...lead, last]
+  /**
+   * {@link unfold `Tree.unfold`} accepts a `path` and a `leaf` and creates the
+   * data structure that the pair describes (with `leaf` as the terminal value).
+   * 
+   * @example
+   *  type MySparseTree = Tree.unfold<[x: 0, y: 1], ["a", "b", "c"]>
+   *  //   ^? type MySparseTree = { a: { b: { c: [x: 0, y: 1] } } }
+   */
+  type unfold<path extends any.path, leaf = unknown> = unfold.go<path, leaf>
+  namespace unfold {
+    type go<path extends any.path, leaf>
+      = path extends empty.array ? leaf
+      : path extends nonempty.pathLeft<infer init, infer last>
+      ? unfold.go<init, any.named<[last: last, value: leaf]>>
+      : never
+      ;
+  }
 
-  type merge<t> = never
-    | [t] extends [any.primitive] ? t
-    : { [k in t extends any.object ? keyof t : never]
-      : merge<t extends any.indexedBy<k> ? t[k] : never> }
-    ;
+  /**
+   * {@link merge `Tree.merge`} expects a union of trees to merge, and merges them.
+   * 
+   * Performant, non-distributive, handles value collisions gracefully.
+   * 
+   * **Note:** Because {@link merge `Tree.merge`} is non-distributive, you'll get
+   * the best results if any possible collisions belong to the same basic "kind".
+   * 
+   * If you try to merge a primitive (like `number`) with a composite (like `Array`),
+   * you'll end up merging their "prototypes".
+   * 
+   * @example
+   *  declare const myTree: Tree.merge<
+   *    | { a: 1, b: { c: 2, d: 3, g: { i: 8 } }, e: 4 } 
+   *    | { a: 5, b: { f: 6, g: { h: 7 } } }
+   *  >
+   * 
+   *  type MyTreeTest = expect<assert.equal<
+   *    // ^? type MyTreeTest = "✅"
+   *    typeof myTree,
+   *    { a: 1 | 5, b: { c: 2, f: 6, d: 3, g: { i: 8, h: 7 } }, e: 4 }
+   *  >>
+   */
+  type merge<trees> = never | merge.go<trees>
+  namespace merge {
+    type go<t> = never
+      | [t] extends [any.primitive] ? t
+      : { [k in t extends any.object ? keyof t : never]
+        : merge.go<t extends any.indexedBy<k> ? t[k] : never> }
+  }
 
-  type shift<xs extends pathable>
-    = xs extends readonly [any.index<infer head>, ...pathable<infer tail>] ? any.two<head, tail> : never
+  type shift<xs extends pathable> = Tree.fromPaths.NEXT<xs>
 
+  /**
+   * @example
+   *  type input = { a: { b: { c: { d: 2, e: 3 }, f: 4 }, g: 5 }, h: 6 }
+   *  type ex_01
+   *    // ^? type ex_01 = 2
+   *    = input extends Tree.traversableBy<["a", "b", "c", "d"], infer T>
+   *    // even though `T` was declared as an inline variable, the type
+   *    // system is aware that it has the path that we inferred above
+   *    ? T["a"]["b"]["c"]["d"]
+   *    : never
+   *    ;
+   */
+  type traversableBy<
+    invariant extends any.path,
+    type extends
+    | Tree.unfold<invariant, {}>
+    = Tree.unfold<invariant, {}>
+  > = type
 
   /** 
-   * {@link fromPaths `Tree.fromPaths`} is a type constructor that accepts either a union or 
-   * an array of {@link pathable `Tree.pathable`} types, and performs a **breadth-first**
-   * traversal, successively grouping paths with a common first element under the same key 
-   * in the tree.
+   * {@link fromPaths `Tree.fromPaths`} is a type constructor that 
+   * _accepts either a union, or an array_ of {@link pathable `Tree.pathable`} types
+   * and performs a **breadth-first** traversal, successively grouping paths with a common 
+   * first element under the same key in the tree.
+   * 
+   * @example
+   *  type TestMyTree = expect<assert.equal<
+   *    // ^? type TestMyTree = "✅"
+   *    Tree.fromPaths<[
+   *      ["abc", "def", "ghi", "jkl"],
+   *      ["abc", "mno", "pqr"],
+   *      ["abc", "def", "stu", "vwx", ["y", "z"]],
+   *      [0, 1, [2, 3, 4]],
+   *      [0, 5, 6],
+   *    ]>,
+   *    {
+   *      abc: {
+   *        mno: "pqr",
+   *        def: {
+   *          ghi: "jkl",
+   *          stu: { 
+   *            vwx: ["y", "z"] 
+   *          }
+   *        },
+   *      },
+   *      0: { 
+   *        1: [2, 3, 4], 
+   *        5: 6
+   *      }
+   *    }
+   *  >>
    */
   type fromPaths<paths extends pathable | any.array<pathable>>
-    = go.breadthFirst<paths extends pathable ? paths : paths[number]>
+    = fromPaths.go<paths extends pathable ? paths : paths[number]>
+    ;
+  namespace fromPaths {
+    type DONE = any.one
+    type NEXT<xs extends pathable>
+      = xs extends readonly [any.index<infer head>, ...pathable<infer tail>] ? any.pair<head, tail>
+      : never
+    type go<xs extends pathable>
+      = [xs] extends [DONE] ? xs[0] : { [next in NEXT<xs> as next[0]]: fromPaths.go<next[1]> }
+  }
 
-  /** @internal */
-  namespace go {
-    type breadthFirst<xs extends pathable>
-      = [xs] extends [any.one] ? xs[0]
-      : { [e in Tree.shift<xs> as e[0]]: go.breadthFirst<e[1]> }
+  /**
+   * {@link traversal `Tree.traversal`} takes a tree and a path into that
+   * tree and walks the path, returning whatever it finds there.
+   * 
+   * Note: this type is not related to
+   * {@link https://hackage.haskell.org/package/lens-5.3.1/docs/Control-Lens-Traversal.html `Traversal`},
+   * nor does it describe an iterative "walking" of a tree from OO.
+   * 
+   * @example
+   *  type three = Tree.traversal<{ a: { b: { c: 3 }, d: 4 } }, ["a", "b", "c"]>
+   */
+  type traversal<
+    tree,
+    path extends any.array<any.index>,
+  > = traversal.go<tree, path>
+  namespace traversal {
+    type go<
+      tree,
+      path extends any.array<any.index>,
+    > = path extends empty.path ? tree
+      : path extends nonempty.path<any.keyof<tree, infer head>, infer tail>
+      ? traversal<tree[head], tail>
+      : never
       ;
   }
 }


### PR DESCRIPTION
Closes #110 

## changelog

### additions
- :memo: adds documentation for all of the type constructors in `Tree`

### deprecations
- 🗑️ `traversable.by` - use `Tree.traversableBy` instead
- 🗑️ `traversal.of` - use `Tree.traversal` instead
