### PR TITLE
feat: adds `has` module

### DIFF
--- a/.changeset/spicy-plums-tap.md
+++ b/.changeset/spicy-plums-tap.md
@@ -1,0 +1,44 @@
+---
+"any-ts": minor
+---
+
+feat: adds `has` module
+- `has.oneProperty` lets you express a constraint that the input type contains exactly 1 property. For example:
+
+  ```typescript
+  /** 
+   * @example
+   *  const one = singleton({ a: 1 })       // ✅
+
+   *  const zero = singleton({})            // 🚫
+   *  //    ^? const zero: never
+   *  const two = singleton({ a: 1, b: 2 }) // 🚫
+   *  //    ^? const two: never
+   */
+  declare function singleton<const T extends has.oneProperty<T>>(objectWithExactlyOneProperty: T): T
+  ```
+
+  **Note:** `has.oneProperty` accepts 2 additional optional type parameters
+  1. an invariant, which allows you to apply an additional constraint on the type of the property itself; and
+  2. a "debug" flag, which, if non-never, changes the behavior of `has.oneProperty` to raise a custom `TypeError` if `T` fails to satisfy the constraint
+
+- `has.oneElement`
+  ```typescript
+
+  /** 
+   * @example
+   *  const one = singleton([1])    // ✅
+   *  //    ^? const one: readonly [1]
+   * 
+   *  const zero = singleton([])    // 🚫
+   *  //    ^? const zero: never
+   *  const two = singleton([1, 2]) // 🚫
+   *  //    ^? const two: never
+   */
+  declare function oneNumber<const T extends has.oneElement<T, number>>(tupleContainingOneNumber: T): T
+  ```
+
+  **Note:** like `has.oneProperty`, `has.oneElement` also accepts 2 additional optional type parameters
+  1. an invariant, which allows you to apply an additional constraint on the type of the element itself; and,
+  2. a "debug" flag, which, if non-never, changes the behavior of `has.oneElement` to raise a custom `TypeError` if `T` fails to satisfy the constraint
+

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -15,6 +15,7 @@ export type { object } from "./object/exports.js"
 export type { boolean } from "./boolean/exports.js"
 export type { cache } from "./cache/exports.js"
 export type { evaluate } from "./evaluate/exports.js"
+export type { has } from "./has/exports.js"
 export type { check, typecheck } from "./check/exports.js"
 export type {
   Catch,

--- a/src/has/exports.ts
+++ b/src/has/exports.ts
@@ -1,0 +1,1 @@
+export type { has } from "./has.js"

--- a/src/has/has.test.ts
+++ b/src/has/has.test.ts
@@ -1,0 +1,110 @@
+import { has } from "./has.js"
+
+namespace happy_path {
+  export type ex_01 = has.oneProperty<{ a: 1 }>
+  //           ^?
+
+  export type ex_02 = has.oneProperty<{ a: 1 }, number>
+  //           ^?
+
+  export type ex_03 = has.oneProperty.debug<{ a: 1 }>
+  //           ^?
+
+  export type ex_04 = has.oneProperty.debug<{ a: 1 }, number>
+  //           ^?
+
+  export const ex_05 = has.oneProperty({ a: 1 })
+  //           ^?
+
+  export const ex_06 = has.oneProperty<number>()({ a: 1 })
+  //           ^?
+
+  export const ex_07 = has.oneProperty.debug({ a: 1 })
+  //           ^?
+
+  export const ex_08 = has.oneProperty.debug({ a: 1 })
+  //           ^?
+}
+
+namespace unhappy_path {
+  export type ex_01 = has.oneProperty<[1]>
+  //           ^?
+
+  export type ex_02 = has.oneProperty<{}>
+  //           ^?
+
+  export type ex_03 = has.oneProperty<{}, number>
+  //           ^?
+
+  export type ex_04 = has.oneProperty<{ a: 1, b: 2 }>
+  //           ^?
+
+  export type ex_05 = has.oneProperty<{ a: 1, b: 2 }, number>
+  //           ^?
+
+  //////////////
+  /// DEBUG
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: [1]]> */
+  export type ex_06 = has.oneProperty.debug<[1]>
+  //           ^?
+
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: {}]> */
+  export type ex_07 = has.oneProperty.debug<{}>
+  //           ^?
+
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: {}]> */
+  export type ex_08 = has.oneProperty.debug<{}, number>
+  //           ^?
+
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: { a: 1, b: 2 }]> */
+  export type ex_09 = has.oneProperty.debug<{ a: 1, b: 2 }>
+  //           ^?
+
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: { a: 1, b: 2 }]> */
+  export type ex_10 = has.oneProperty.debug<{ a: 1, b: 2 }, number>
+  //           ^?
+
+  /** @ts-expect-error: never */
+  export const ex_11 = has.oneProperty({})
+  //           ^?
+
+  /** @ts-expect-error: never */
+  export const ex_12 = has.oneProperty<number>()({})
+  //           ^?
+
+  /** @ts-expect-error: never */
+  export const ex_13 = has.oneProperty({ a: 1, b: 2 })
+  //           ^?
+
+  /** @ts-expect-error: never */
+  export const ex_14 = has.oneProperty<number>()({ a: 1, b: 2 })
+  //           ^?
+
+  /** @ts-expect-error: Type 'number' is not assignable to type 'boolean' */
+  export const ex_15 = has.oneProperty<boolean>()({ a: 1 })
+  //           ^?
+
+  /** @ts-expect-error: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type 'never' */
+  export const ex_16 = has.oneProperty<boolean>()({ a: 1, b: 2 })
+  //           ^?
+
+  /** @ts-expect-error: TypeError<[msg: "Expected an object with exactly one property", got: {}]> */
+  export const ex_17 = has.oneProperty.debug({})
+  //           ^?
+
+  /** @ts-expect-error: Argument of type '{}' is not assignable to parameter of type 'TypeError_<[msg: "Expected an object with exactly one property", got: {}]>' */
+  export const ex_18 = has.oneProperty.debug<number>()({})
+  //           ^?
+
+  /** @ts-expect-error: Object literal may only specify known properties, and 'a' does not exist in type 'TypeError_<[msg: "Expected an object with exactly one property", got: { readonly a: 1; readonly b: 2; }]>' */
+  export const ex_19 = has.oneProperty.debug({ a: 1, b: 2 })
+  //           ^?
+
+  /** @ts-expect-error: Object literal may only specify known properties, and 'a' does not exist in type 'TypeError_<[msg: "Expected an object with exactly one property", got: { readonly a: 1; readonly b: 2; }]>' */
+  export const ex_20 = has.oneProperty.debug<number>()({ a: 1, b: 2 })
+  //           ^?
+
+  /** @ts-expect-error: Object literal may only specify known properties, and 'a' does not exist in type 'TypeError_<[msg: "Expected an object with exactly one property", got: { readonly a: 1; readonly b: 2; }]>' */
+  export const ex_21 = has.oneProperty.debug<boolean>()({ a: 1, b: 2 })
+  //           ^?
+}

--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -3,6 +3,41 @@ import { _ } from "../util.js";
 import type { TypeError } from "../type-error/exports.js"
 
 export declare namespace has {
+  /** 
+   * ### [`has.oneProperty`](has.oneProperty) 
+   * 
+   * [`has.oneProperty`](has.oneProperty) allows users to constrain a type parameter 
+   * such that it only accepts objects that contain exactly 1 property.
+   *
+   * @example
+   *  import type { has } from "any-ts"
+   * 
+   *  declare function exactlyOne<const T extends has.oneProperty<T>>(singleton: T): T
+   *  declare function exactlyOne<const T extends has.oneProperty<T, unknown, "debug">>(one: T, _?: any): T
+   *
+   *  const ex_01 = exactlyOne({ a: 1 })
+   *  //    ^? const ex_01: { readonly a: 1 }
+   *
+   *  const ex_02 = exactlyOne({}) // 🚫 TypeError: '{} is not assignable to parameter of type 'never'
+   *  //    ^? const ex_02: never
+   * 
+   *  const ex_03 = exactlyOne({ a: 1, b: 2 }) // 🚫 TypeError: '{ a: 1, b: 2 } is not assignable to parameter of type 'never'
+   *  //    ^? const ex_02: never
+   *
+   *  const ex_04 = exactlyOne({ a: 1 }, "debug")
+   *  //    ^? const ex_03: { readonly a: 1 }
+   *
+   *  const ex_05 = exactlyOne({}, "debug")
+   *  //                        ^? 
+   *  // 🚫 Argument of type '{}' is not assignable to parameter of type 
+   *  // 'TypeError_<[msg: "Expected an object containing exactly one property", got: {}]>'
+   *
+   *  /// Demonstrates using `has.oneProperty` to apply an arbitrary constraint to the property:
+   *  declare function exactlyOneString<const T extends has.oneProperty<T, string>>(one: T): T
+   *
+   *  const ex_06 = exactlyOneString({ a: 1 })
+   *  //                               ^? 🚫 Type 'number' is not assignable to type 'string'
+   */
   export type oneProperty<type, invariant = _, debug = never>
     = [any.unit] extends [test$$.hasExactlyOneProp<type>] ? any.dict<invariant>
     : [debug] extends [never] ? never
@@ -18,6 +53,38 @@ export declare namespace has {
     function debug<const T extends has.oneProperty<T, _, "debug">>(oneProperty: T): T
   }
 
+  /** 
+   * ### [`has.oneElement`](has.oneElement) 
+   * 
+   * [`has.oneElement`](has.oneElement) allows users to constrain a type parameter 
+   * such that it only accepts tuples that contain exactly 1 element.
+   *
+   * @example
+   *  import type { has } from "any-ts"
+   * 
+   *  declare function exactlyOne<const T extends has.oneElement<T>>(singleton: T): T
+   *  declare function exactlyOne<const T extends has.oneElement<T, unknown, "debug">>(one: T, _?: any): T
+   *
+   *  const ex_01 = exactlyOne([1])
+   *  //    ^? const ex_01: readonly [1]
+   *
+   *  const ex_02 = exactlyOne([1, 2]) // 🚫 TypeError: 'number[]' is not assignable to parameter of type 'never'
+   *  //    ^? const ex_02: never
+   *
+   *  const ex_03 = exactlyOne([1], "debug")
+   *  //    ^? const ex_03: readonly [1]
+   *
+   *  const ex_04 = exactlyOne([1, 2], "debug")
+   *  //                        ^? 
+   *  // 🚫 Argument of type 'number[]' is not assignable to parameter of type 
+   *  // 'TypeError_<[msg: "Expected a tuple containing exactly one element", got: readonly [1, 2]]>'
+   *
+   *  /// Demonstrates using `has.oneElement` to apply an arbitrary constraint to the element:
+   *  declare function exactlyOneString<const T extends has.oneElement<T, string>>(one: T): T
+   *
+   *  const ex_05 = exactlyOneString([1])
+   *  //                              ^? 🚫 Type 'number' is not assignable to type 'string'
+   */
   export type oneElement<type, invariant = _, debug = never>
     = [any.unit] extends [test$$.hasExactlyOneElement<type>] ? any.array<invariant>
     : [debug] extends [never] ? never
@@ -47,3 +114,4 @@ export declare namespace has {
     type hasExactlyOneElement<t> = [1] extends [t[Extract<"length", keyof t>]] ? any.unit : never
   }
 }
+

--- a/src/has/has.ts
+++ b/src/has/has.ts
@@ -1,0 +1,49 @@
+import type { any } from "../any/exports.js"
+import { _ } from "../util.js";
+import type { TypeError } from "../type-error/exports.js"
+
+export declare namespace has {
+  export type oneProperty<type, invariant = _, debug = never>
+    = [any.unit] extends [test$$.hasExactlyOneProp<type>] ? any.dict<invariant>
+    : [debug] extends [never] ? never
+    : TypeError.new<"Expected an object with exactly one property", type>
+    ;
+
+  export function oneProperty<Invariant = never>(): <const T extends has.oneProperty<T, Invariant>>(oneProperty: T) => T
+  export function oneProperty<const T extends has.oneProperty<T>>(oneProperty: T): T
+  export namespace oneProperty {
+    type debug<type extends has.oneProperty<type, _, "debug">, invariant = _> = has.oneProperty<type, invariant, "debug">
+
+    function debug<Invariant = never>(): <const T extends has.oneProperty<T, Invariant, "debug">>(oneProperty: T) => T
+    function debug<const T extends has.oneProperty<T, _, "debug">>(oneProperty: T): T
+  }
+
+  export type oneElement<type, invariant = _, debug = never>
+    = [any.unit] extends [test$$.hasExactlyOneElement<type>] ? any.array<invariant>
+    : [debug] extends [never] ? never
+    : TypeError.new<"Expected a tuple containing exactly one element", type>
+    ;
+  export function oneElement<Invariant = never>(): <const T extends has.oneElement<T, Invariant>>(singleton: T) => T
+  export function oneElement<const T extends has.oneElement<T>>(singleton: T): T
+  export namespace oneElement {
+    type debug<type extends has.oneElement<type, _, "debug">, invariant = _> = has.oneElement<type, invariant, "debug">
+
+    function debug<Invariant = never>(): <const T extends has.oneElement<T, Invariant, "debug">>(oneElement: T) => T
+    function debug<const T extends has.oneElement<T, _, "debug">>(oneElement: T): T
+  }
+}
+
+export declare namespace has {
+  namespace test$$ {
+    type isUnion<t, u = t> = u extends u ? [t, u] extends [u, t] ? never : any.unit : never
+    type hasExactlyOneProp<t>
+      = [keyof t] extends [infer key]
+      ? [key] extends [never] ? never
+      : [any.unit] extends [isUnion<key>] ? never
+      : any.unit
+      : never
+      ;
+
+    type hasExactlyOneElement<t> = [1] extends [t[Extract<"length", keyof t>]] ? any.unit : never
+  }
+}


### PR DESCRIPTION
## changelog

### new module: [`has`](https://github.com/ahrjarrett/any-ts/commit/d0fe782d49600a2c6c832f4af416e98c6ac7ba17)

- [`has.oneProperty`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.43.8?expand=1#diff-cf3a8efa47fc31128046113035a76d5235dbfe67578a35f1874c6c52cc52f650R6-R9) 
  - `has.oneProperty` lets you express the type of an object that contains exactly 1 property. 
 
  For example:
  ```typescript
  /** 
   * @example
   *  const one = singleton({ a: 1 })       // ✅
   * 
   *  const zero = singleton({})            // 🚫
   *  //    ^? const zero: never
   * 
   *  const two = singleton({ a: 1, b: 2 }) // 🚫
   *  //    ^? const two: never
   */
  declare function singleton<const T extends has.oneProperty<T>>(
    objectWithExactlyOneProperty: T
  ): T
  ```

- [`has.oneProperty.debug`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.43.8?expand=1#diff-cf3a8efa47fc31128046113035a76d5235dbfe67578a35f1874c6c52cc52f650R15)
  - `has.oneProperty.debug` is like `has.oneProperty`, but raises a `TypeError` if `T` has 0 or 2+ properties

- [`has.oneElement`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.43.8?expand=1#diff-cf3a8efa47fc31128046113035a76d5235dbfe67578a35f1874c6c52cc52f650R21-R25)
  - `has.oneElement` lets you express the type of an tuple that contains exactly 1 property.
    
  For example:

  ```typescript
  /** 
   * @example
   *  const one = singleton([1])    // ✅
   *  //    ^? const one: readonly [1]
   * 
   *  const zero = singleton([])    // 🚫
   *  //    ^? const zero: never
   *  const two = singleton([1, 2]) // 🚫
   *  //    ^? const two: never
   */
  declare function oneNumber<const T extends has.oneElement<T, number>>(
    tupleContainingOneNumber: T
  ): T
  ```
- [`has.oneElement.debug`](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.43.8?expand=1#diff-cf3a8efa47fc31128046113035a76d5235dbfe67578a35f1874c6c52cc52f650R29)
  - `has.oneElement.debug` is like `has.oneElement`, but raises a `TypeError` if `T` has 0 or 2+ elements



#### Notes
- Both `has.oneProperty` and `has.oneElement` both accept 2 additional optional type parameters:
  1. an `invariant` param, which allows you to apply an additional constraint on the type of the property itself; and
  2. a `debug` flag, which, if non-never, changes the behavior of `has.one*` to raise a `TypeError` if `T` fails to satisfy the constraint