### PR TITLE
fix: account for contravariance in index signature of `any.dict`

### DIFF
--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -274,7 +274,7 @@ export type any_type<type extends any_nullable | any_nonnullable = any_nullable 
 export type any_key<type extends string | number = string | number> = type
 export type any_scalar = string | number | boolean | null
 
-export interface any_dict<type = _> { [ix: keyof never]: type }
+export interface any_dict<type = _> { [ix: string]: type }
 export type any_array<type = _> = readonly type[]
 /** @ts-expect-error */
 export interface any_object<type extends object = object> extends id<type> { }

--- a/src/object/object.ts
+++ b/src/object/object.ts
@@ -15,7 +15,7 @@ export declare namespace signature {
     <A, B>(guard: any.typeguard<A, B>): <const T extends any.dict<A>>(object: T) => filter.values<T, B>
     <A>(predicate: some.predicate<A>): <const T extends any.dict<A>>(object: T) => filter.values<T, A>
     <A, B, const T extends any.dict<A>>(object: T, guard: any.typeguard<A, B>): filter.values<T, B>
-    <A, const T extends any.dict<A>>(object: T, predicate: some.predicate<A>,): filter.values<T, A>
+    <A, const T extends any.dict<A>>(object: T, predicate: some.predicate<A>): filter.values<T, A>
   }
 
   /** @experimental */


### PR DESCRIPTION
## changelog

### fixes
- [fix: account for contravariance in index signature of any.dict](https://github.com/ahrjarrett/any-ts/commit/65cbdb53254b21b588d6e68d8dbcad59d6c6d8dd)

This change makes `any.dict` more permissive in covariant position, and more restrictive in the contravariant position.

Technically this is a breaking change, but only in cases where `any.dict` was being used in contravariant position and the concrete type included at least 1 symbol in their signature.

If this breaks anything for you, please open an issue and we'll figure out a way to make this change backwards compatible.