### PR TITLE
@ahrjarrett/v0.47.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,12 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "access": "public",
   "baseBranch": "main",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "ahrjarrett/any-ts"
+    }
+  ],
   "commit": false,
   "fixed": [],
   "ignore": [],

--- a/.changeset/grumpy-otters-walk.md
+++ b/.changeset/grumpy-otters-walk.md
@@ -1,0 +1,12 @@
+---
+"any-ts": minor
+---
+
+break: renames `match.finite*` to `match.finite.*`
+
+for example: 
+
+```
+match.finiteArray -> match.finite.array
+match.nonfiniteArray -> match.nonfinite.array
+```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@arktype/attest": "^0.7.3",
+    "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "@types/node": "^20.12.7",
     "init": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@arktype/attest':
         specifier: ^0.7.3
         version: 0.7.3(typescript@5.3.3)
+      '@changesets/changelog-github':
+        specifier: ^0.5.0
+        version: 0.5.0
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
@@ -75,6 +78,9 @@ packages:
   '@changesets/changelog-git@0.2.0':
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
 
+  '@changesets/changelog-github@0.5.0':
+    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
+
   '@changesets/cli@2.27.1':
     resolution: {integrity: sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==}
     hasBin: true
@@ -87,6 +93,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.0.0':
     resolution: {integrity: sha512-cafUXponivK4vBgZ3yLu944mTvam06XEn2IZGjjKc0antpenkYANXiiE6GExV/yKdsCnE8dXVZ25yGqLYZmScA==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@4.0.0':
     resolution: {integrity: sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==}
@@ -776,6 +785,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -819,6 +831,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1342,6 +1358,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
@@ -1792,6 +1817,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -1951,8 +1979,14 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -2117,6 +2151,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
 
+  '@changesets/changelog-github@0.5.0':
+    dependencies:
+      '@changesets/get-github-info': 0.6.0
+      '@changesets/types': 6.0.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.27.1':
     dependencies:
       '@babel/runtime': 7.24.4
@@ -2173,6 +2215,13 @@ snapshots:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 7.6.0
+
+  '@changesets/get-github-info@0.6.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.0':
     dependencies:
@@ -2778,6 +2827,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  dataloader@1.4.0: {}
+
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -2816,6 +2867,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dotenv@8.6.0: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -3414,6 +3467,10 @@ snapshots:
 
   nanoid@3.3.7: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -3872,6 +3929,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -4042,7 +4101,14 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@4.0.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:

--- a/src/match/match.ts
+++ b/src/match/match.ts
@@ -1,32 +1,33 @@
+import type { some } from "../some/some.js";
 import type { any } from "../any/any.js"
 import type { never } from "../never/never.js"
 
 export type {
-  match_finiteArray as finiteArray,
-  match_finiteBoolean as finiteBoolean,
-  match_finiteKey as finiteKey,
-  match_finiteIndex as finiteIndex,
-  match_finiteLiteral as finiteLiteral,
-  match_finiteNumber as finiteNumber,
-  match_finiteString as finiteString,
-
-}
-
-export type {
-  match_record as record,
   match_emptyObject as emptyObject,
-  match_nonfiniteArray as nonfiniteArray,
-  match_strict as strict,
 }
 
-declare namespace match_strict {
+export declare namespace finite {
   export {
-    match_finiteBooleanStrict as finiteBoolean,
-    match_strictSubsetOf as subsetOf,
+    match_finiteBoolean as boolean,
+    match_finiteKey as key,
+    match_finiteIndex as index,
+    match_finiteLiteral as literal,
+    match_finiteNumber as number,
+    match_finiteString as string,
+    match_finiteObject as object,
+    match_finiteArray as array,
   }
 }
 
-type match_finiteArray<t>
+export declare namespace nonfinite {
+  export {
+    match_nonfiniteArray as array,
+    match_nonfiniteObject as record,
+    match_nonfiniteObject as object,
+  }
+}
+
+export type match_finiteArray<t>
   = [
     t extends any.array
     ? number extends t["length"] ? never
@@ -35,7 +36,7 @@ type match_finiteArray<t>
   ] extends [infer out extends any.array] ? out : never
   ;
 
-type match_nonfiniteArray<t>
+export type match_nonfiniteArray<t>
   = [
     t extends any.array
     ? number extends t["length"] ? t
@@ -44,63 +45,109 @@ type match_nonfiniteArray<t>
   ] extends [infer out] ? out : never
   ;
 
-type match_record<t>
-  = [t] extends [any.struct]
-  ? [t] extends [any.array]
-  ? never
-  : any.struct
-  : never
-  ;
-
-type match_emptyObject<t>
+export type match_emptyObject<t>
   = [t] extends [any.struct]
   ? [keyof t] extends [never] ? {}
   : never
   : never
   ;
 
-type match_finiteString<t>
+export type match_finiteString<t>
   = [t] extends [string]
   ? [string] extends [t] ? never
   : string
   : never
   ;
 
-type match_finiteNumber<t>
+export type match_finiteNumber<t>
   = [t] extends [number]
   ? [number] extends [t] ? never
   : number
   : never
   ;
 
-type match_finiteBoolean<t>
-  = [globalThis.Extract<t, boolean>] extends [infer out]
+export type match_finiteBoolean<t>
+  = [Extract<t, boolean>] extends [infer out]
   ? [boolean] extends [out] ? never
   : out
   : never
   ;
 
-type match_finiteBooleanStrict<t>
+export type match_finiteBooleanStrict<t>
   = [[t] extends [boolean] ? [boolean] extends [t] ? never : t : never] extends [infer out]
   ? out
   : never
   ;
 
-type match_finiteKey<t>
+export type match_finiteKey<t>
   = [t] extends [any.key]
   ? any.key extends t ? never
   : any.key
   : never
   ;
 
-type match_finiteIndex<t> = match_strict.subsetOf<t, any.index>
+export type match_finiteIndex<t>
+  = match_strictSubsetOf<t, any.index>
+  ;
 
-type match_strictSubsetOf<t, set>
+export type match_strictSubsetOf<type, set>
   = set extends set
-  ? [set extends t ? never : globalThis.Extract<t, set>] extends [infer out]
+  ? [set extends type ? never : Extract<type, set>] extends [infer out]
   ? out
   : never.close.inline_var<"out">
   : never.close.distributive<"set">
   ;
 
-type match_finiteLiteral<t> = match_finiteBoolean<t> | match_strict.subsetOf<t, any.key>
+export type match_finiteLiteral<t>
+  = match_finiteBoolean<t>
+  | match_strictSubsetOf<t, any.key>
+  ;
+
+export type match_nonfiniteObject<t, value = unknown>
+  = [t] extends [object]
+  ? [t] extends [any.array] ? never
+  : [string] extends [keyof t] ? { [x: string]: value }
+  : [number] extends [keyof t] ? { [x: number]: value }
+  : [symbol] extends [keyof t] ? { [x: symbol]: value }
+  : never
+  : never
+  ;
+
+export type match_nonfiniteStruct<t, value = unknown>
+  = [t] extends [object]
+  ? [t] extends [any.array]
+  ? [number] extends [t["length"]] ? any.array<value> : never
+  : [string] extends [keyof t] ? { [x: string]: value }
+  : [number] extends [keyof t] ? { [x: number]: value }
+  : [symbol] extends [keyof t] ? { [x: symbol]: value }
+  : never
+  : never
+  ;
+
+export type match_finiteStruct<t, value = unknown>
+  = [t] extends [object]
+  ? [t] extends [any.array]
+  ? [number] extends [t["length"]] ? never : any.array<value>
+  : [string] extends [keyof t] ? never
+  : [number] extends [keyof t] ? never
+  : [symbol] extends [keyof t] ? never
+  : { [x: any.key]: value }
+  : never
+  ;
+
+export type match_finiteObject<t, constraint extends object = {}>
+  = [t] extends [object]
+  ? [t] extends [any.array] ? never
+  : [string] extends [keyof t] ? never
+  : [number] extends [keyof t] ? never
+  : [symbol] extends [keyof t] ? never
+  : constraint
+  : never
+  ;
+
+export declare namespace strict {
+  export {
+    match_finiteBooleanStrict as finiteBoolean,
+    match_strictSubsetOf as subsetOf,
+  }
+}


### PR DESCRIPTION
## changelog

### breaking change: 

- [renames match.finite* to match.finite.*](https://github.com/ahrjarrett/any-ts/commit/a7adb1e56d077246920d2acf8d1256ad49588787) 
-- e.g. `match.finiteArray` -> `match.finite.array`

### new features:
- not dist-related, but this PR also porkbarrels a switch to using `@changesets/github` to generate the changelog.