### PR TITLE
v0.47.0 [cont'd]: (re-exports `some.instanceOf`, adds `any.maybeIndexedBy`)

### DIFF
--- a/.changeset/neat-melons-fix.md
+++ b/.changeset/neat-melons-fix.md
@@ -1,0 +1,5 @@
+---
+"any-ts": patch
+---
+
+fix: re-exports `some.instanceOf`; feat: adds `any.maybeIndexedBy`

--- a/src/any/any.ts
+++ b/src/any/any.ts
@@ -205,6 +205,13 @@ declare namespace any {
     = { [ix in invariant]: _ }
   > = type
 
+  export type maybeIndexedBy<
+    invariant extends any.index,
+    type extends
+    | { [ix in invariant]+?: _ }
+    = { [ix in invariant]+?: _ }
+  > = type
+
   export type indexableBy<
     invariant extends any.index,
     type extends

--- a/src/some/some.ts
+++ b/src/some/some.ts
@@ -65,6 +65,8 @@ export declare namespace some {
     some_fieldOf as fieldOf,
     /** {@link some_subtypeOf `some.subtypeOf`} @external */
     some_subtypeOf as subtypeOf,
+    /** {@link some_instanceOf `some.instanceOf`} @external */
+    some_instanceOf as instanceOf,
   }
 }
 


### PR DESCRIPTION
supercedes #159 

## changelog

### fixes
- re-exports `some.instanceOf`

### new features
- adds `any.maybeIndexedBy`
