### PR TITLE
fix: `some.entriesOf` infers the right thing when used in matching position

### DIFF
--- a/.changeset/orange-frogs-join.md
+++ b/.changeset/orange-frogs-join.md
@@ -1,0 +1,5 @@
+---
+"any-ts": patch
+---
+
+fix: `some.entriesOf` when used in matching position

--- a/src/some/some.ts
+++ b/src/some/some.ts
@@ -180,8 +180,8 @@ export type some_entryOf<
 export type some_entriesOf<
   invariant,
   type extends
-  | any.array<readonly [any.index, invariant]>
-  = any.array<readonly [any.index, invariant]>
+  | any.array<any.pair<keyof invariant, invariant[keyof invariant]>>
+  = any.array<any.pair<keyof invariant, invariant[keyof invariant]>>
 > = type
 
 export type some_arrayOf<


### PR DESCRIPTION
## changelog

### fixes
- [fix: fixes some.entriesOf](https://github.com/ahrjarrett/any-ts/commit/d80e9e1616904055a2f691e74f0a0f5c97b54c54)
