### PR TITLE
deprecates `Identity` - use `newtype` instead

### DIFF
--- a/.changeset/rotten-rules-appear.md
+++ b/.changeset/rotten-rules-appear.md
@@ -1,0 +1,5 @@
+---
+"any-ts": patch
+---
+
+deprecate: `Identity` -- use `newtype` instead

--- a/src/check/check.ts
+++ b/src/check/check.ts
@@ -12,10 +12,10 @@ export {
 
 import type { any } from "../any/exports.js"
 import type { _ } from "../util.js"
-import type { Identity as id } from "../identity.js"
+import type { newtype } from "../newtype.js"
 
 export type TypeErrorURI = "any-ts/TypeError"
-export interface TypeError<type extends [string, unknown]> extends id<type> {
+export interface TypeError<type extends [string, unknown]> extends newtype<type> {
   [any.unit]: TypeErrorURI
 }
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -60,7 +60,11 @@ export type {
 } from "./mutable/exports.js"
 export type { pathsof } from "./paths/exports.js"
 export type { never } from "./never/exports.js"
-export type { Identity } from "./identity.js"
+export type {
+  newtype,
+  /** @deprecated use {@link newtype `newtype`} instead */
+  newtype as Identity,
+} from "./newtype.js"
 export type { id } from "./util.js"
 export type {
   char,

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,4 +1,0 @@
-import type { id } from "./util.js";
-
-/** @ts-expect-error hush */
-export interface Identity<nonunion extends {} = {}> extends id<nonunion> { }

--- a/src/newtype.ts
+++ b/src/newtype.ts
@@ -1,0 +1,4 @@
+import type { id } from "./util.js";
+
+/** @ts-expect-error hush */
+export interface newtype<nonunion extends {} = {}> extends id<nonunion> { }

--- a/src/string/string.ts
+++ b/src/string/string.ts
@@ -10,6 +10,7 @@ import type * as Internal from "./_internal.js"
 import type { Case } from "./_internal.js"
 import type { /* join, */ startsWith, endsWith } from "./_internal.js"
 import type { is } from "./_internal.js"
+import { newtype } from "../newtype.js"
 
 import type { char } from "./char.js"
 
@@ -22,6 +23,16 @@ declare namespace HKT {
   namespace is {
     interface uppercaseAlphaChar extends Kind<[any.showable]> { [-1]: char.is.uppercaseAlpha<`${this[0]}`> }
   }
+}
+
+////////////////
+/// newtypes
+declare namespace string {
+  interface literal<T extends string = string> extends newtype<string> { toString(): T, valueOf(): T }
+  interface decodedURI<T extends string = string> extends string.literal<T> { }
+  interface encodedURI<T extends string = string> extends string.literal<T> { }
+  interface decodedURIComponent<T extends string = string> extends string.literal<T> { }
+  interface encodedURIComponent<T extends string = string> extends string.literal<T> { }
 }
 
 declare namespace string {


### PR DESCRIPTION
## changelog

It also re-names `Identity` to `newtype`, to give users a signal as to its intended purpose.

### new features
- adds "newtype" `string.literal`
- adds "newtype" `string.decodedURI`
- adds "newtype" `string.encodedURI`
- adds `string.decodedURIComponent`
- adds `string.encodedURIComponent`

### deprecations
- [deprecates: Identity -- use newtype instead](https://github.com/ahrjarrett/any-ts/commit/04acf77c59f6e0fe9c47183588ea4258c5be28e3)
This release adds a handful of ["newtypes"](https://doc.rust-lang.org/rust-by-example/generics/new_types.html). These newtypes behave a bit differently than branded or flavored types, since they (in the examples that this PR introduces) are simply _interfaces that wrap the native `string` type_.

This is accomplished by wrapping the naked type parameter in a wrapper function called (in this library) `id`. `id` is just the identity function: it simply gives back what its given.

```typescript
type id<x> = x
interface newtype<type extends any.nonnullable = {}> extends id<type> {}
```

Now that we have `newtype`, we can implement `string.literal`:

```typescript
interface string_literal<type extends string = string> extends newtype<string> { 
    toString(): type
    valueOf(): type
}

declare namespace string {
    export { string_literal as literal }
}
```

Notice that **we're not passing the `type` parameter to `newtype`. We're passing the universal string type (`string`).

By doing that, we're _choosing a prototype that values with this type should have available_.

To make this type more useful, we override the `toString` and `valueOf` methods, so that they return the narrowed type of `type`.

There! We've now implemented a custom `string` type, and overridden one of its methods, `toString`, to return a custom type.

All of its behavior is the same; all we've done is told the TS compiler that we want it to track some extra information at the typelevel.

We could take this further -- I'm not sure yet if this is a good idea or not, but for completeness, let's try overridding `String.prototype.concat`:

```typescript
  interface string_literal<T extends string = string> extends newtype<string> { 
    toString(): T, 
    valueOf(): T, 
    concat<U extends string>(postfix: U): string.literal<`${T}${U}`>
  }
```

Notice that we're re-wrapping the output in `string.literal`, that way we can continue concatenating if we wanted without having to re-wrap the output in `string.literal`.

Here's what using it looks like:

<img width="865" alt="string literal concat" src="https://github.com/user-attachments/assets/3ec14f1b-b1cf-467d-9238-74defed39cdf">

That's awesome. Until today I didn't know this kind of thing was possible in the TypeScript type system -- as far as I know, this kind of thing isn't being done anywhere else (but I'd love to hear about it if you know of other libraries doing this!).


One last problem we need to take care of.

When we override `String.prototype.concat`, we get a new TypeError:

<img width="1059" alt="Screenshot 2024-07-20 at 9 37 30 PM" src="https://github.com/user-attachments/assets/ffcf6c57-37f6-49ec-86bb-e03fceed440c">

This TypeError actually makes sense: in fact, that's the whole reason we're creating these `newtypes`, is _so that the type system can tell the difference between a string and the new type that we're creating_.

In this case though the TypeError is undesirable, since we're intentionally overriding its type-level behavior.

How can we get our new concat to play nice with the global `String` prototype?

The trick is to simply say that we don't want to use `String.prototype.concat`'s type signature at all:

```typescript
interface string_literal<T extends string = string> extends newtype<globalThis.Omit<string, "concat">> { 
    toString(): t
    valueOf(): t
    concat<U extends string>(postfix: u): string.literal<`${T}${U}`>
}
```

And with that, we've implemented a new type whose type-level behavior inherits from the native `string` type, but preserves type information even while concatting.

I hope these release notes were useful, or at least interesting, and as always, thanks for keeping an open mind as we explore these things together.

