### PR TITLE
breaking(Universal): switch to a more intuitive API

### DIFF
--- a/.changeset/blue-otters-poke.md
+++ b/.changeset/blue-otters-poke.md
@@ -1,0 +1,5 @@
+---
+"any-ts": minor
+---
+
+break(Universal): switch over to a more intuitive API

--- a/.changeset/blue-otters-poke.md
+++ b/.changeset/blue-otters-poke.md
@@ -2,4 +2,8 @@
 "any-ts": minor
 ---
 
-break(Universal): switch over to a more intuitive API
+### breaking changes
+- All of the members of Universal namespace have changed their implementations
+  - Since `any-ts` is still pre v1.0, this is a minor version bump.
+  - The API is relatively stable; I expect one (1) more breaking change before releasing v1.0.0 this fall
+

--- a/src/associative/associative.ts
+++ b/src/associative/associative.ts
@@ -18,14 +18,14 @@ declare namespace Universal {
   type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
 
   type key<key extends any.index> =
-    | `${Exclude<key, symbol>}`
+    | `${globalThis.Exclude<key, symbol>}`
     | parseNumeric<key>
     | key
     ;
 
   type keyof<type>
     = type extends any.array
-    ? Universal.key<Extract<keyof type, `${number}`>>
+    ? Universal.key<globalThis.Extract<keyof type, `${number}`>>
     : Universal.key<keyof type>
     ;
 
@@ -55,7 +55,7 @@ type size$ = typeof size$
 
 declare namespace impl {
   type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
-  type asArraylike<type extends any.array> = never | { [ix in size$ | Extract<keyof type, `${number}`>]: ix extends keyof type ? type[ix] : type["length"] }
+  type asArraylike<type extends any.array> = never | { [ix in size$ | globalThis.Extract<keyof type, `${number}`>]: ix extends keyof type ? type[ix] : type["length"] }
 
   type toEntries<type, order extends any.array<keyof type>>
     = never | { [ix in keyof order]: [order[ix], type[order[ix]]] }
@@ -87,7 +87,7 @@ namespace impl {
   } as new <const type extends object>(type: type) => type;
 
   export const rangeInclusive
-    : <x extends enforce.positiveNumber<x>>(upperBound: x) => impl.rangeInclusive<[], Extract<x, number>>
+    : <x extends enforce.positiveNumber<x>>(upperBound: x) => impl.rangeInclusive<[], globalThis.Extract<x, number>>
     = (upperBound) => {
       let acc = []
       if (!real.is$(upperBound)) return [] as never
@@ -95,7 +95,7 @@ namespace impl {
       return acc as never
     }
   export const rangeExclusive
-    : <x extends enforce.positiveNumber<x>>(upperBound: x) => impl.rangeExclusive<[], Extract<x, number>>
+    : <x extends enforce.positiveNumber<x>>(upperBound: x) => impl.rangeExclusive<[], globalThis.Extract<x, number>>
     = (upperBound) => {
       let acc = []
       if (!real.is$(upperBound)) return [] as never
@@ -112,7 +112,7 @@ declare const is
 
 type of<type extends any.entries> = never | [
   { [e in type[number]as e[0]]: e[1] },
-  Extract<{ -readonly [ix in keyof type]: type[ix][0] }, any.array>,
+  globalThis.Extract<{ -readonly [ix in keyof type]: type[ix][0] }, any.array>,
 ]
 
 type make<
@@ -200,7 +200,7 @@ type keys<type extends Any>
   ;
 
 declare const keyof: <type extends Any>(assoc: type) => Assoc.keyof<type>
-type keyof<type extends Any> = Exclude<keyof type, number | size$>
+type keyof<type extends Any> = globalThis.Exclude<keyof type, number | size$>
 
 /** @ts-expect-error - internal use only */
 class assoc<const type extends any.object> extends impl.base<type> { }

--- a/src/associative/associative.ts
+++ b/src/associative/associative.ts
@@ -6,13 +6,48 @@ export {
 import type { any } from "../any/exports.js"
 import { assert, describe, expect } from "../test/exports.js"
 import type { TypeError } from "../err/exports.js"
-import type { Universal } from "../universal/exports.js"
 import type { cache } from "../cache/exports.js"
 import type { iter } from "../iter/exports.js"
 import type { enforce } from "../err/enforce.js"
 import type { never } from "../never/exports.js"
 import { real } from "../number/real.js"
 import { _ } from "../util.js"
+
+// import type { Universal } from "../universal/exports.js"
+declare namespace Universal {
+  type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
+
+  type key<key extends any.index> =
+    | `${Exclude<key, symbol>}`
+    | parseNumeric<key>
+    | key
+    ;
+
+  type keyof<type>
+    = type extends any.array
+    ? Universal.key<Extract<keyof type, `${number}`>>
+    : Universal.key<keyof type>
+    ;
+
+  type get<index extends any.key, type>
+    = index extends keyof type ? type[index]
+    : parseNumeric<index> extends any.number<infer x>
+    ? x extends keyof type ? type[x]
+    : never
+    : `${index}` extends any.string<infer s>
+    ? s extends keyof type ? type[s]
+    : never
+    : never
+    ;
+
+  type values<type>
+    = type extends any.array
+    ? type[number]
+    : type extends any.object
+    ? type[keyof type]
+    : type
+    ;
+}
 
 const size$: unique symbol = Symbol.for("any-ts/associative::size$")
 type size$ = typeof size$
@@ -150,7 +185,7 @@ declare const separate
 
 type is<type>
   = [type] extends [{ [size$]: number }]
-  ? Exclude<type, any.array> extends infer nonArray
+  ? globalThis.Exclude<type, any.array> extends infer nonArray
   ? [nonArray] extends [never] ? false
   : impl.is<type>
   : false

--- a/src/show/associative.ts
+++ b/src/show/associative.ts
@@ -15,7 +15,6 @@ import { describe, expect } from "../test/exports.js"
 import type { enforce } from "../err/enforce.js"
 import type { TypeError } from "../err/exports.js"
 import type { never } from "../never/exports.js"
-import type { Universal } from "../universal/exports.js"
 import type { assoc as _ } from "../associative/exports.js"
 
 const len$: unique symbol = Symbol.for("TypeConstructor/assoc::len")
@@ -23,6 +22,41 @@ type len$ = typeof len$
 const tag$: unique symbol = Symbol.for("TypeConstructor/assoc::tag")
 type tag$ = typeof tag$
 
+// import type { Universal } from "../universal/exports.js"
+declare namespace Universal {
+  type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
+
+  type key<key extends any.index> =
+    | `${Exclude<key, symbol>}`
+    | parseNumeric<key>
+    | key
+    ;
+
+  type keyof<type>
+    = type extends any.array
+    ? Universal.key<Extract<keyof type, `${number}`>>
+    : Universal.key<keyof type>
+    ;
+
+  type get<index extends any.key, type>
+    = index extends keyof type ? type[index]
+    : parseNumeric<index> extends any.number<infer x>
+    ? x extends keyof type ? type[x]
+    : never
+    : `${index}` extends any.string<infer s>
+    ? s extends keyof type ? type[s]
+    : never
+    : never
+    ;
+
+  type values<type>
+    = type extends any.array
+    ? type[number]
+    : type extends any.object
+    ? type[keyof type]
+    : type
+    ;
+}
 
 type Tag<type extends keyof typeof Tag = keyof typeof Tag> = typeof Tag[type]
 declare namespace Tag {
@@ -272,3 +306,5 @@ declare namespace __Spec__ {
     expect<assert.equal<Tag<"object" | "union" | "intersection">, "|" | "&" | "{}">>,
   ]
 }
+
+const t = separate(Assoc("&", ["abc", 123]))

--- a/src/show/associative.ts
+++ b/src/show/associative.ts
@@ -306,5 +306,3 @@ declare namespace __Spec__ {
     expect<assert.equal<Tag<"object" | "union" | "intersection">, "|" | "&" | "{}">>,
   ]
 }
-
-const t = separate(Assoc("&", ["abc", 123]))

--- a/src/show/associative.ts
+++ b/src/show/associative.ts
@@ -27,14 +27,14 @@ declare namespace Universal {
   type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
 
   type key<key extends any.index> =
-    | `${Exclude<key, symbol>}`
+    | `${globalThis.Exclude<key, symbol>}`
     | parseNumeric<key>
     | key
     ;
 
   type keyof<type>
     = type extends any.array
-    ? Universal.key<Extract<keyof type, `${number}`>>
+    ? Universal.key<globalThis.Extract<keyof type, `${number}`>>
     : Universal.key<keyof type>
     ;
 
@@ -75,7 +75,7 @@ namespace Tag {
 
 type is<type>
   = [type] extends [{ [len$]: number, [tag$]: Tag }]
-  ? Exclude<type, any.array> extends infer nonArray
+  ? globalThis.Exclude<type, any.array> extends infer nonArray
   ? [nonArray] extends [never] ? false
   : impl.is<type>
   : false
@@ -86,7 +86,7 @@ type index<acc extends any.array, type extends { [len$]: number }>
   = acc["length"] extends type[len$ & keyof type] ? acc
   : index<[
     ...acc,
-    Extract<type, any.indexedBy<acc["length"]>>[acc["length"]]],
+    globalThis.Extract<type, any.indexedBy<acc["length"]>>[acc["length"]]],
     type
   >
   ;
@@ -100,8 +100,8 @@ type separate<type extends { [len$]: number, [tag$]: Tag }>
   = index<[], type> extends infer index
   ? readonly [
     tag: type[tag$],
-    order: { [ix in Extract<keyof index, `${number}`>]: index[ix] },
-    object: { [ix in Exclude<keyof type, number | tag$ | len$>]: type[ix] },
+    order: { [ix in globalThis.Extract<keyof index, `${number}`>]: index[ix] },
+    object: { [ix in globalThis.Exclude<keyof type, number | tag$ | len$>]: type[ix] },
   ]
   : never
   ;
@@ -124,7 +124,7 @@ declare namespace impl {
     = [separate<type>] extends [readonly [any, infer order, infer object_]]
     ? [
       extra_keys: (keyof order extends infer ord ? ord extends keyof order ? order[ord] extends keyof object_ ? never : ord : never : never),
-      extra_values: Exclude<keyof type, Universal.values<order> | len$ | tag$ | number | `${number}`>
+      extra_values: globalThis.Exclude<keyof type, Universal.values<order> | len$ | tag$ | number | `${number}`>
     ] extends [never, never]
     ? true : false : false
     ;
@@ -132,7 +132,7 @@ declare namespace impl {
     = never | { [ix in keyof order]: [order[ix], type[order[ix]]] }
     ;
   type asArraylike<type extends any.array> = never |
-    { [ix in len$ | Extract<keyof type, `${number}`> as Universal.key<ix>]
+    { [ix in len$ | globalThis.Extract<keyof type, `${number}`> as Universal.key<ix>]
       : ix extends keyof type ? type[ix]
       : ix extends len$ ? type["length"] & number
       : never }
@@ -141,7 +141,7 @@ declare namespace impl {
     ;
   type of<type extends any.entries> = never | [
     { [e in type[number]as e[0]]: e[1] },
-    Extract<{ -readonly [ix in keyof type]: type[ix][0] }, any.array>,
+    globalThis.Extract<{ -readonly [ix in keyof type]: type[ix][0] }, any.array>,
   ]
   type make<
     type,

--- a/src/string/_internal.ts
+++ b/src/string/_internal.ts
@@ -47,7 +47,7 @@ declare namespace is {
   type uppercaseAlpha<type extends string> = boolean.all<[is.uppercase<type>, is.alpha<type>]>
   type lowercaseAlpha<type extends string> = boolean.all<[is.lowercase<type>, is.alpha<type>]>
   type parsableNumeric<type extends string>
-    = Universal.parseNumeric<type> extends any.number<infer x>
+    = Universal.parseInt<type> extends any.number<infer x>
     ? [x] extends [never]
     ? false : true : false
     ;

--- a/src/universal/universal.ts
+++ b/src/universal/universal.ts
@@ -4,38 +4,17 @@ export {
 
 import type { any } from "../any/exports.js"
 
-
 declare namespace Universal {
-  type parseNumeric<type> = type extends `${infer x extends number}` ? x : never
+  /** @internal */
+  type parseInt<t> = [t] extends [`${infer n extends number}`] ? n : t;
 
-  type key<key extends any.index> =
-    | `${Exclude<key, symbol>}`
-    | parseNumeric<key>
-    | key
-    ;
+  /** ### {@link Universal.get `Universal.get`} */
+  type get<t, k extends any.index> = t[keyOf<t, k>]
 
-  type keyof<type>
-    = type extends any.array
-    ? Universal.key<Extract<keyof type, `${number}`>>
-    : Universal.key<keyof type>
-    ;
+  /** ### {@link Universal.keyOf `Universal.keyOf`} */
+  type keyOf<t, k extends any.index = keyof t>
+    = (k extends any.key ? (`${k}` | parseInt<k>) : unknown) & keyof t
 
-  type get<index extends any.key, type>
-    = index extends keyof type ? type[index]
-    : parseNumeric<index> extends any.number<infer x>
-    ? x extends keyof type ? type[x]
-    : never
-    : `${index}` extends any.string<infer s>
-    ? s extends keyof type ? type[s]
-    : never
-    : never
-    ;
-
-  type values<type>
-    = type extends any.array
-    ? type[number]
-    : type extends any.object
-    ? type[keyof type]
-    : type
-    ;
+  /** ### {@link Universal.key `Universal.key`} */
+  type key<k> = `${k & any.showable}` | globalThis.Exclude<k, any.showable>
 }


### PR DESCRIPTION
## changelog

### breaking changes
- All of the members of `Universal` namespace have changed their implementations. Since we're pre v1.0, this warrants a minor version. I expect one more breaking change before releasing v1.0.0 this fall.

