### PR TITLE
@ahrjarrett/v0.48.1

### DIFF
--- a/.changeset/mighty-yaks-compare.md
+++ b/.changeset/mighty-yaks-compare.md
@@ -1,0 +1,19 @@
+---
+"any-ts": patch
+---
+
+feat: adds `inline` type utility
+    
+`inline` is basically a type-level identity function. like its runtime counterpart,
+it turns out to be pretty useful.
+
+```typescript
+import type { inline } from "any-ts"
+
+interface MyTuple extends inline<number[]> {}
+
+declare const myTuple: MyTuple
+
+const copy = [...myTuple]
+//     ^? const copy: number[]
+```

--- a/.changeset/mighty-yaks-compare.md
+++ b/.changeset/mighty-yaks-compare.md
@@ -2,18 +2,40 @@
 "any-ts": patch
 ---
 
+
 feat: adds `inline` type utility
     
-`inline` is basically a type-level identity function. like its runtime counterpart,
-it turns out to be pretty useful.
+
+
+
+
+### new features
+
+- new [inline](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.48.1?expand=1#diff-8f609800e1fe1486238044764d22867704573f7319ac89246dfcedfe9b3d7b68R9) utility
+
+`inline` is basically a type-level identity function. 
+
+like its runtime counterpart, it can be pretty useful.
+
+the name `inline` refers to the particular use case that I personally usually use it for, 
+which is for wrapping a type literal so that an interface can extend it.
 
 ```typescript
 import type { inline } from "any-ts"
 
-interface MyTuple extends inline<number[]> {}
+//////////////
+/// example
 
-declare const myTuple: MyTuple
+/** 
+ * did you know you can make an interface out of an array?
+ * this can be useful when you want to preserve the
+ * identifier:             vvvv   */
+interface Numbers extends inline<number[]> {}
 
-const copy = [...myTuple]
-//     ^? const copy: number[]
+declare const numbers: Numbers
+//            ^? const numbers: Numbers
+
+// normal array behavior is preserved:
+const copy = [...ex_01.numbers]
+//    ^? const copy: number[]
 ```

--- a/.changeset/mighty-yaks-compare.md
+++ b/.changeset/mighty-yaks-compare.md
@@ -2,12 +2,7 @@
 "any-ts": patch
 ---
 
-
 feat: adds `inline` type utility
-    
-
-
-
 
 ### new features
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -6,6 +6,8 @@ export {
   expectToFail
 } from "./test/exports.js"
 
+export type inline<T> = T
+
 export type { empty } from "./empty/exports.js"
 export type { nonempty } from "./nonempty/exports.js"
 export type { array, nonemptyArray, queue, tuple } from "./array/exports.js"


### PR DESCRIPTION
Closes:
- #172 

## changelog

### new features

- new [inline](https://github.com/ahrjarrett/any-ts/compare/%40ahrjarrett/v0.48.1?expand=1#diff-8f609800e1fe1486238044764d22867704573f7319ac89246dfcedfe9b3d7b68R9) utility

`inline` is basically a type-level identity function. 

like its runtime counterpart, it can be pretty useful.

the name `inline` refers to the particular use case that I usually use it for, which is for wrapping a type literal so that an interface can extend it.

```typescript
import type { inline } from "any-ts"

//////////////
/// example

/** 
 * did you know you can make an interface out of an array?
 * this can be useful when you want to preserve the
 * identifier:             vvvv   */
interface Numbers extends inline<number[]> {}

declare const numbers: Numbers
//            ^? const numbers: Numbers

// normal array behavior is preserved:
const copy = [...ex_01.numbers]
//    ^? const copy: number[]
```